### PR TITLE
Add carrayify decorator to Cython code

### DIFF
--- a/src/geocat/comp/_ncomp/ncomp.pyx
+++ b/src/geocat/comp/_ncomp/ncomp.pyx
@@ -8,6 +8,21 @@ import numpy as np
 cimport numpy as np
 import functools
 
+def carrayify(f):
+    """
+    A decorator that ensures that :class:`numpy.ndarray` arguments are
+    C-contiguous in memory. The decorator function takes no arguments.
+    """
+    @functools.wraps(f)
+    def wrapper(*args, **kwargs):
+        new_args = list(args)
+        for i, arg in enumerate(new_args):
+            if isinstance(arg, np.ndarray) and not arg.flags.carray:
+                new_args[i] = np.ascontiguousarray(arg)
+        return f(*new_args, **kwargs)
+    return wrapper
+
+
 dtype_default_fill = {
              "DEFAULT_FILL":       ncomp.DEFAULT_FILL_DOUBLE,
              np.dtype(np.int8):    np.int8(ncomp.DEFAULT_FILL_INT8),

--- a/test/test_carrayify.py
+++ b/test/test_carrayify.py
@@ -1,0 +1,19 @@
+import numpy as np
+import xarray as xr
+from geocat.comp._ncomp import carrayify
+
+import sys
+import time
+import unittest as ut
+
+class Test_carrayify(ut.TestCase):
+    def test_carrayify_one_arg(self):
+        @carrayify
+        def new_func(a):
+            return a
+        a = np.array([1, 2, 3])
+        b = a[::-1]
+        c = new_func(a)
+        self.assertTrue(a.flags.carray)
+        self.assertFalse(b.flags.carray)
+        self.assertTrue(c.flags.carray)


### PR DESCRIPTION
Using this decorator on a function in ncomp.pyx will ensure that all of that function's numpy.ndarray arguments are C-contiguous in memory.

The decorator function iterates over each input argument, checks if the argument is an instance of numpy.ndarray, then checks if its CARRAY flag is set (meaning the C_CONTIGUOUS, ALIGNED, and BEHAVED flags are all True), and then calls numpy.ascontiguousarray() on the argument array and inserts the new contiguous array into the argument list in place of the original non-contiguous array.

This decorator uses functools.wraps to ensure docstrings of all wrapped functions are preserved.
