### PR TITLE
carrayify linint2

### DIFF
--- a/src/geocat/comp/__init__.py
+++ b/src/geocat/comp/__init__.py
@@ -14,6 +14,11 @@ class ChunkError(Error):
     incompatible with an _ncomp function."""
     pass
 
+class CoordinateError(Error):
+    """Exception raised when a GeoCAT-comp function is passed a NumPy array as
+    an argument without a required coordinate array being passed separately."""
+    pass
+
 def linint2(fi, xo, yo, icycx, msg=None, meta=True, xi=None, yi=None):
     """Interpolates a regular grid to a rectilinear one using bi-linear
     interpolation.
@@ -104,9 +109,12 @@ def linint2(fi, xo, yo, icycx, msg=None, meta=True, xi=None, yi=None):
             array.
 
             Note:
-                If left unspecified, the rightmost coordinate dimension
-                of fi will be used. This parameter must be specified as
-                a keyword argument.
+                If fi is of type :class:`xarray.DataArray` and xi is
+                left unspecified, then the rightmost coordinate
+                dimension of fi will be used. If fi is not of type
+                :class:`xarray.DataArray`, then xi becomes a mandatory
+                parameter. This parameter must be specified as a keyword
+                argument.
 
         yi (:class:`numpy.ndarray`):
             An array that specifies the Y coordinates of the fi array.
@@ -125,9 +133,12 @@ def linint2(fi, xo, yo, icycx, msg=None, meta=True, xi=None, yi=None):
             For geo-referenced data, yi is generally the latitude array.
 
             Note:
-                If left unspecified, the second-to-rightmost coordinate
-                dimension of fi will be used. This parameter must be
-                specified as a keyword argument.
+                If fi is of type :class:`xarray.DataArray` and xi is
+                left unspecified, then the second-to-rightmost
+                coordinate dimension of fi will be used. If fi is not of
+                type :class:`xarray.DataArray`, then xi becomes a
+                mandatory parameter. This parameter must be specified as
+                a keyword argument.
 
     Returns:
         :class:`xarray.DataArray`: The interpolated grid. If the *meta*
@@ -174,6 +185,9 @@ def linint2(fi, xo, yo, icycx, msg=None, meta=True, xi=None, yi=None):
 
     if not isinstance(fi, xr.DataArray):
         fi = xr.DataArray(fi)
+        if xi is None or yi is None:
+            raise CoordinateError("linint2: arguments xi and yi must be passed"
+                    " explicitly if fi is not an xarray.DataArray.")
 
     if xi is None:
         xi = fi.coords[fi.dims[-1]].values

--- a/src/geocat/comp/_ncomp/ncomp.pyx
+++ b/src/geocat/comp/_ncomp/ncomp.pyx
@@ -7,6 +7,13 @@ import cython
 import numpy as np
 cimport numpy as np
 import functools
+import warnings
+
+class NcompWarning(Warning):
+    pass
+
+class NcompError(Exception):
+    pass
 
 def carrayify(f):
     """
@@ -286,6 +293,9 @@ def _linint2(np.ndarray xi, np.ndarray yi, np.ndarray fi, np.ndarray xo, np.ndar
             icycx, iopt)
 #   re-acquire interpreter lock
 #   check errors ier
+    if ier:
+        warnings.warn("linint2: {}: xi, yi, xo, and yo must be monotonically increasing".format(ier),
+                      NcompWarning)
 
     if missing_inds_fi is not None and missing_inds_fi.any():
         fi[missing_inds_fi] = np.nan

--- a/src/geocat/comp/_ncomp/ncomp.pyx
+++ b/src/geocat/comp/_ncomp/ncomp.pyx
@@ -140,9 +140,11 @@ cdef set_ncomp_msg(ncomp.ncomp_missing* ncomp_msg, num):
     elif ncomp_type == ncomp.NCOMP_LONGDOUBLE:
         ncomp_msg.msg_longdouble = ncomp_to_dtype[ncomp_type](num)
 
-@cython.embedsignature(True)
+@carrayify
 def _linint2(np.ndarray xi, np.ndarray yi, np.ndarray fi, np.ndarray xo, np.ndarray yo, int icycx, msg=None):
-    """Interpolates a regular grid to a rectilinear one using bi-linear
+    """_linint2(xi, yi, fi, xo, yo, icycx, msg=None)
+
+    Interpolates a regular grid to a rectilinear one using bi-linear
     interpolation.
 
     linint2 uses bilinear interpolation to interpolate from one


### PR DESCRIPTION
Add @carrayify decorator to `_ncomp._linint2`.

Throw a warning in `_ncomp._linint2` for non-monotonic coord arrays.

Create CoordinateError, raise it in linint2. `CoordinateError`s should be raised when a GeoCAT-comp function is passed a NumPy array as an argument without a required coordinate array being passed separately.

If the fi argument passed to linint2 is not an xarray.DataArray, and either of xi or yi is not explicitly passed to linint2, then there are no valid coordinate arrays for linint2 to use, and a CoordinateError is raised.

Add new test cases to test_linint2.py

New tests handle non-contiguous input arrays (fixed by @carrayify) and non-monotonic coordinate arrays (_ncomp._linint2 now raises a warning, and a test case is used to assert that the warning is thrown).

Note that this PR is currently using the `carrayify` branch as its base, but I intend to change it to `develop` once #33 is merged.