### PR TITLE
Re-enable dpres_plevel test

### DIFF
--- a/test/test_dpres_plevel.py
+++ b/test/test_dpres_plevel.py
@@ -25,3 +25,8 @@ class Test_rcm2points_float64(ut.TestCase):
         result_dp = geocat.comp.dpres_plevel(plev, psfc)
         np.testing.assert_array_equal(expected_dp, result_dp.values)
 
+class Test_dpres_plevel_float32(ut.TestCase):
+    def test_dpres_plevel_float32(self):
+        plev_asfloat32 = plev.astype(np.float32)
+        result_dp = geocat.comp.dpres_plevel(plev_asfloat32, psfc)
+        np.testing.assert_array_equal(expected_dp, result_dp.values)

--- a/test/test_dpres_plevel.py
+++ b/test/test_dpres_plevel.py
@@ -20,8 +20,8 @@ expected_dp = np.array( [4300., 5000., 5000., 5000., 5000., 5000., 5000., 5000.,
 			 3750., 2500., 2500., 2500., 2250., 1500., 1000., 1000.,
 			 1000., 1000., 750., 500., 750., 500.] )
 
-class Test_rcm2points_float64(ut.TestCase):
-    def test_rcm2points_float64(self):
+class Test_dpres_plevel_float64(ut.TestCase):
+    def test_dpres_plevel_float64(self):
         result_dp = geocat.comp.dpres_plevel(plev, psfc)
         np.testing.assert_array_equal(expected_dp, result_dp.values)
 


### PR DESCRIPTION
One of the `dpres_plevel` tests was removed in #53 because it was causing issues. This PR re-enables the broken test and will be used to diagnose the issue.

The following builds on CircleCI all experienced failures in `test_dpres_plevel.py`, see the "Run tests" sections for more info:
https://circleci.com/gh/NCAR/geocat-comp/578
https://circleci.com/gh/NCAR/geocat-comp/580
https://circleci.com/gh/NCAR/geocat-comp/596

Notably, the tests do not consistently fail, and I've only seen them fail on CircleCI (never on my own machine).