### PR TITLE
Reconfigure dependencies

### DIFF
--- a/.circleci/run-checks.sh
+++ b/.circleci/run-checks.sh
@@ -5,7 +5,4 @@ set -eo pipefail
 
 source activate ${ENV_NAME}
 
-pip install netcdf4
-pip install scipy
-
 pytest --verbose test


### PR DESCRIPTION
This PR reconfigures dependencies, which became necessary after geocat-comp vs geocat-ncomp separation.