### PR TITLE
Conda builds from release tags and changed version settings

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -93,10 +93,9 @@ author = u'Orhan Eroglu'
 #''' moved into function, can now be used other places
 def read_version():
     for line in open('../meta.yaml').readlines():
-        index = line.find('version')
+        index = line.find('set version')
         if index > -1:
-            return line[index + 8:].replace('\'', '').strip()
-
+            return line[index + 15:].replace('\" %}', '').strip()
 
 # The short X.Y version.
 version = read_version()

--- a/meta.yaml
+++ b/meta.yaml
@@ -1,6 +1,8 @@
+{% set version = "2021.02.0" %}
+
 package:
   name: 'geocat-comp'
-  version: '2021.02.0'
+  version: {{ version }}
 
 build:
   noarch: python
@@ -8,8 +10,9 @@ build:
   skip: True  # [py<3.5]
 
 source:
-  git_rev: main
-  git_url: https://github.com/NCAR/geocat-comp.git
+#  git_rev: main
+#  git_url: https://github.com/NCAR/geocat-comp.git
+  url: https://github.com/NCAR/geocat-comp/archive/v{{ version }}.tar.gz   # Fetch from Github repo tags
 
 requirements:
   host:

--- a/meta.yaml
+++ b/meta.yaml
@@ -10,9 +10,9 @@ build:
   skip: True  # [py<3.5]
 
 source:
-#  git_rev: main
-#  git_url: https://github.com/NCAR/geocat-comp.git
-  url: https://github.com/NCAR/geocat-comp/archive/v{{ version }}.tar.gz   # Fetch from Github repo tags
+  git_rev: v{{ version }}
+  git_url: https://github.com/NCAR/geocat-comp.git
+  #url: https://github.com/NCAR/geocat-comp/archive/v{{ version }}.tar.gz   # Fetch from Github repo tags
 
 requirements:
   host:

--- a/meta.yaml
+++ b/meta.yaml
@@ -10,9 +10,10 @@ build:
   skip: True  # [py<3.5]
 
 source:
-  git_rev: v{{ version }}
+  #git_rev: main   # For debugging purposes
+  git_rev: v{{ version }}   # For pulling tag as a branch
   git_url: https://github.com/NCAR/geocat-comp.git
-  #url: https://github.com/NCAR/geocat-comp/archive/v{{ version }}.tar.gz   # Fetch from Github repo tags
+  #url: https://github.com/NCAR/geocat-comp/archive/v{{ version }}.tar.gz   # Fetch from Github repo tags' tarballs
 
 requirements:
   host:

--- a/setup.py
+++ b/setup.py
@@ -2,14 +2,12 @@
 from setuptools import setup, find_packages
 from pathlib import Path
 
-
 #''' moved into function, can now be used other places
 def version():
     for line in open('meta.yaml').readlines():
-        index = line.find('version')
+        index = line.find('set version')
         if index > -1:
-            return line[index + 8:].replace('\'', '').strip()
-
+            return line[index + 15:].replace('\" %}', '').strip()
 
 setup(
     name='geocat.comp',


### PR DESCRIPTION
Closes #109 

In an effort to respond to above issue, this PR modifies `meta.yml` and other relevant files to fetch release version from this repo's tags instead of source code in `main` branch.