### PR TITLE
Bumped version number for new release

### DIFF
--- a/meta.yaml
+++ b/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2021.02.0" %}
+{% set version = "2021.03.0" %}
 
 package:
   name: 'geocat-comp'


### PR DESCRIPTION
This just bumps version to "2021.03.0" for new release