### PR TITLE
Remove edit on github button

### DIFF
--- a/docs/_templates/breadcrumbs.html
+++ b/docs/_templates/breadcrumbs.html
@@ -1,0 +1,4 @@
+{%- extends "sphinx_rtd_theme/breadcrumbs.html" %}
+
+{% block breadcrumbs_aside %}
+{% endblock %}


### PR DESCRIPTION
Addresses #121 

Summary of changes:
- overrides sphinx theme read the docs button

See the [activated branch on RTD](https://geocat-comp.readthedocs.io/en/remove_rtd_edit_button/)
