### PR TITLE
Apply a Workaround for Metpy's Issue with 4D Xarray in interp_hybrid_to_sigma 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,6 @@ cf_xarray>=0.3.1
 dask[array]
 eofs
 geocat-f2py
+metpy
 numpy
 xarray

--- a/src/geocat/comp/interp_hybrid_to_pressure.py
+++ b/src/geocat/comp/interp_hybrid_to_pressure.py
@@ -120,20 +120,15 @@ def interp_hybrid_to_pressure(data,
     #     }},
     # )
 
-    if isinstance(data, xr.DataArray):
-        # If an unchunked Xarray input is given, chunk it just with its dims
-        if (data.chunks is None):
-            data_chunk = dict([
-                (k, v) for (k, v) in zip(list(data.dims), list(data.shape))
-            ])
-            data = data.chunk(data_chunk)
+    # If an unchunked Xarray input is given, chunk it just with its dims
+    if (data.chunks is None):
+        data_chunk = dict([
+            (k, v) for (k, v) in zip(list(data.dims), list(data.shape))
+        ])
+        data = data.chunk(data_chunk)
 
-        if (pressure.chunks is None):
-            pressure_chunk = dict([
-                (k, v)
-                for (k, v) in zip(list(pressure.dims), list(pressure.shape))
-            ])
-            pressure = pressure.chunk(pressure_chunk)
+    # Chunk pressure equal to data's chunks
+    pressure = pressure.chunk(data.chunks)
 
     # Output data structure elements
     out_chunks = list(data.chunks)

--- a/src/geocat/comp/interp_hybrid_to_pressure.py
+++ b/src/geocat/comp/interp_hybrid_to_pressure.py
@@ -121,7 +121,7 @@ def interp_hybrid_to_pressure(data,
     # )
 
     # If an unchunked Xarray input is given, chunk it just with its dims
-    if (data.chunks is None):
+    if data.chunks is None:
         data_chunk = dict([
             (k, v) for (k, v) in zip(list(data.dims), list(data.shape))
         ])

--- a/src/geocat/comp/interp_hybrid_to_pressure.py
+++ b/src/geocat/comp/interp_hybrid_to_pressure.py
@@ -162,7 +162,7 @@ def interp_hybrid_to_pressure(data,
         data.dims[i] if i != interp_axis else "plev" for i in range(data.ndim)
     ]
 
-    # This is needed with the existence of above workaround block
+    # Rename output dims. This is only needed with above workaround block
     dims_dict = {output.dims[i]: dims[i] for i in range(len(output.dims))}
     output = output.rename(dims_dict)
 

--- a/src/geocat/comp/interp_hybrid_to_pressure.py
+++ b/src/geocat/comp/interp_hybrid_to_pressure.py
@@ -96,8 +96,8 @@ def interp_hybrid_to_pressure(data,
     # For the issue with metpy's xarray interface:
     #
     # `metpy.interpolate.interpolate_1d` had "no implementation found for
-    # 'numpy.apply_along_axis'" for cases where the input is xarray.Dataarray
-    # and has more than 3 dimensions (e.g. 4th dim of `time`).
+    # 'numpy.apply_along_axis'" issue for cases where the input is
+    # xarray.Dataarray and has more than 3 dimensions (e.g. 4th dim of `time`).
 
     # Use dask.array.core.map_blocks instead of xarray.apply_ufunc and
     # auto-chunk input arrays to ensure using only Numpy interface of
@@ -107,13 +107,13 @@ def interp_hybrid_to_pressure(data,
     # # Apply Dask parallelization with xarray.apply_ufunc
     # output = xr.apply_ufunc(
     #     _vertical_remap,
-    #     data.values,
-    #     pressure.values,
+    #     data,
+    #     pressure,
     #     exclude_dims=set((lev_dim,)),  # Set dimensions allowed to change size
     #     input_core_dims=[[lev_dim], [lev_dim]],  # Set core dimensions
     #     output_core_dims=[["plev"]],  # Specify output dimensions
     #     vectorize=True,  # loop over non-core dims
-    #     # dask="parallelized",  # Dask parallelization
+    #     dask="parallelized",  # Dask parallelization
     #     output_dtypes=[data.dtype],
     #     dask_gufunc_kwargs={"output_sizes": {
     #         "plev": len(new_levels)

--- a/src/geocat/comp/interp_hybrid_to_pressure.py
+++ b/src/geocat/comp/interp_hybrid_to_pressure.py
@@ -1,7 +1,6 @@
 import cf_xarray
 import metpy.interpolate
 import numpy as np
-import xarray
 import xarray as xr
 
 __pres_lev_mandatory__ = np.array([
@@ -150,7 +149,7 @@ def interp_hybrid_to_pressure(data,
     # End of Workaround
     ###############################################################################
 
-    output = xarray.DataArray(output)
+    output = xr.DataArray(output)
 
     # Set output dims and coords
     dims = [

--- a/src/geocat/comp/interp_hybrid_to_pressure.py
+++ b/src/geocat/comp/interp_hybrid_to_pressure.py
@@ -1,6 +1,7 @@
 import cf_xarray
 import metpy.interpolate
 import numpy as np
+import xarray
 import xarray as xr
 
 __pres_lev_mandatory__ = np.array([
@@ -72,6 +73,9 @@ def interp_hybrid_to_pressure(data,
     # Calculate pressure levels at the hybrid levels
     pressure = _pressure_from_hybrid(ps, hyam, hybm, p0)  # Pa
 
+    # Make pressure shape same as data shape
+    pressure = pressure.transpose(*data.dims)
+
     # Define interpolation function
     if method == 'linear':
         func_interpolate = metpy.interpolate.interpolate_1d
@@ -86,26 +90,81 @@ def interp_hybrid_to_pressure(data,
 
         return func_interpolate(new_levels, pressure, data, axis=interp_axis)
 
-    # Apply vertical interpolation
-    # Apply Dask parallelization with xarray.apply_ufunc
-    output = xr.apply_ufunc(
+    ###############################################################################
+    # Workaround
+    #
+    # For the issue with metpy's xarray interface:
+    #
+    # `metpy.interpolate.interpolate_1d` had "no implementation found for
+    # 'numpy.apply_along_axis'" for cases where the input is xarray.Dataarray
+    # and has more than 3 dimensions (e.g. 4th dim of `time`).
+
+    # Use dask.array.core.map_blocks instead of xarray.apply_ufunc and
+    # auto-chunk input arrays to ensure using only Numpy interface of
+    # `metpy.interpolate.interpolate_1d`.
+
+    # # Apply vertical interpolation
+    # # Apply Dask parallelization with xarray.apply_ufunc
+    # output = xr.apply_ufunc(
+    #     _vertical_remap,
+    #     data.values,
+    #     pressure.values,
+    #     exclude_dims=set((lev_dim,)),  # Set dimensions allowed to change size
+    #     input_core_dims=[[lev_dim], [lev_dim]],  # Set core dimensions
+    #     output_core_dims=[["plev"]],  # Specify output dimensions
+    #     vectorize=True,  # loop over non-core dims
+    #     # dask="parallelized",  # Dask parallelization
+    #     output_dtypes=[data.dtype],
+    #     dask_gufunc_kwargs={"output_sizes": {
+    #         "plev": len(new_levels)
+    #     }},
+    # )
+
+    if isinstance(data, xr.DataArray):
+        # If an unchunked Xarray input is given, chunk it just with its dims
+        if (data.chunks is None):
+            data_chunk = dict([
+                (k, v) for (k, v) in zip(list(data.dims), list(data.shape))
+            ])
+            data = data.chunk(data_chunk)
+
+        if (pressure.chunks is None):
+            pressure_chunk = dict([
+                (k, v)
+                for (k, v) in zip(list(pressure.dims), list(pressure.shape))
+            ])
+            pressure = pressure.chunk(pressure_chunk)
+
+    # Output data structure elements
+    out_chunks = list(data.chunks)
+    out_chunks[interp_axis] = (new_levels.size,)
+    out_chunks = tuple(out_chunks)
+    # ''' end of boilerplate
+
+    from dask.array.core import map_blocks
+    output = map_blocks(
         _vertical_remap,
-        data,
-        pressure,
-        exclude_dims=set((lev_dim,)),  # Set dimensions allowed to change size
-        input_core_dims=[[lev_dim], [lev_dim]],  # Set core dimensions
-        output_core_dims=[["plev"]],  # Specify output dimensions
-        vectorize=True,  # loop over non-core dims
-        dask="parallelized",  # Dask parallelization
-        output_dtypes=[data.dtype],
-        dask_gufunc_kwargs={"output_sizes": {
-            "plev": len(new_levels)
-        }},
+        data.data,
+        pressure.data,
+        chunks=out_chunks,
+        dtype=data.dtype,
+        drop_axis=[interp_axis],
+        new_axis=[interp_axis],
     )
 
+    # End of Workaround
+    ###############################################################################
+
+    output = xarray.DataArray(output)
+
     # Set output dims and coords
-    dims = ["plev"
-           ] + [data.dims[i] for i in range(data.ndim) if i != interp_axis]
+    dims = [
+        data.dims[i] if i != interp_axis else "plev" for i in range(data.ndim)
+    ]
+
+    # This is needed with the existence of above workaround block
+    dims_dict = {output.dims[i]: dims[i] for i in range(len(output.dims))}
+    output = output.rename(dims_dict)
 
     coords = {}
     for (k, v) in data.coords.items():

--- a/test/test_interp_hybrid_to_pressure.py
+++ b/test/test_interp_hybrid_to_pressure.py
@@ -57,6 +57,22 @@ class Test_interp_hybrid_to_pressure(TestCase):
 
         nt.assert_array_almost_equal(_uzon_expected, uzon, 5)
 
+    def test_interp_hybrid_to_pressure_atmos_4d(self):
+        data_t = _data.expand_dims("time")
+
+        u_int = interp_hybrid_to_pressure(data_t,
+                                          _ps,
+                                          _hyam,
+                                          _hybm,
+                                          p0=_p0,
+                                          new_levels=_pres3d,
+                                          method="log")
+
+        uzon = u_int.mean(dim='lon')
+
+        uzon_expected_t = _uzon_expected.expand_dims("time")
+        nt.assert_array_almost_equal(uzon_expected_t, uzon, 5)
+
     def test_interp_hybrid_to_pressure_atmos_wrong_method(self):
         with nt.assert_raises(ValueError):
             u_int = interp_hybrid_to_pressure(_data,
@@ -83,50 +99,3 @@ class Test_interp_hybrid_to_pressure(TestCase):
         uzon = u_int.mean(dim='lon')
 
         nt.assert_array_almost_equal(_uzon_expected, uzon, 5)
-
-    # # TODO: Migrate the following code to GeoCAT-examples NCL_conwomap_5
-    # # This test generates a plot, which can be compared to NCL's conwomap_5 plot:
-    # # https://www.ncl.ucar.edu/Applications/Images/conwomap_5_2_lg.png
-    # def test_interp_hybrid_to_pressure_atmos_plot(self):
-    #     u_int = interp_hybrid_to_pressure(_data,
-    #                                       _ps[0, :, :],
-    #                                       _hyam,
-    #                                       _hybm,
-    #                                       p0=_p0,
-    #                                       new_levels=_pres3d,
-    #                                       method="log")
-    #
-    #     uzon = u_int.mean(dim='lon')
-    #
-    #     # Plot:
-    #     # Generate figure (set its size (width, height) in inches) and axes
-    #     plt.figure(figsize=(12, 12))
-    #     ax = plt.gca()
-    #
-    #     # Draw filled contours
-    #     colors = uzon.plot.contourf(ax=ax,
-    #                                 levels=np.arange(-12, 44, 4),
-    #                                 add_colorbar=False,
-    #                                 add_labels=False)
-    #     # Draw contour lines
-    #     lines = uzon.plot.contour(ax=ax,
-    #                               colors='black',
-    #                               levels=np.arange(-12, 44, 4),
-    #                               linewidths=0.5,
-    #                               linestyles='solid',
-    #                               add_labels=False)
-    #
-    #     # Create horizontal colorbar
-    #     cbar = plt.colorbar(colors,
-    #                         ticks=np.arange(-12, 44, 4),
-    #                         orientation='horizontal',
-    #                         drawedges=True,
-    #                         aspect=12,
-    #                         shrink=0.8,
-    #                         pad=0.075)
-    #
-    #     # Show the plot
-    #     plt.tight_layout()
-    #     plt.show(block=False)
-    #     plt.pause(3)
-    #     plt.close()


### PR DESCRIPTION
This PR applies a workaround to `interp_hybrid_to_pressure` function for the issue with `metpy`'s xarray interface:
   
DESCRIPTION: `metpy.interpolate.interpolate_1d` had "no implementation found for 'numpy.apply_along_axis'" error for cases where the input is `xarray.Dataarray` and has more than 3 dimensions (e.g. 4th dim of `time`).

The workaround used in this PR uses `dask.array.core.map_blocks` instead of `xarray.apply_ufunc` and auto-chunks input arrays (if unchunked) to ensure using only `Numpy` interface of `metpy.interpolate.interpolate_1d` (i.e. When call map_blocks with Dask array, it calls Numoy interface of metpy function).