### PR TITLE
Added `cftime` as a dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
           python -m pytest test -v --cov=./src/geocat/comp --cov-report=xml
 
       - name: Upload code coverage to Codecov
-        uses: codecov/codecov-action@v2.0.1
+        uses: codecov/codecov-action@v2.0.2
         with:
           file: ./coverage.xml
           flags: unittests

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -31,14 +31,14 @@ in an existing environment with the following commands:
     conda activate geocat   # or whatever your environment is called
     conda install -c conda-forge matplotlib cartopy jupyter
 
-Please note that the use of the **conda-forge** channel is essential to guarantee
+Please note that the use of the `conda-forge` channel is essential to guarantee
 compatibility between dependency packages.
 
-Also, note that the Conda package manager automatically installs all `required`
+Also, note that the Conda package manager automatically installs all *required*
 dependencies of GeoCAT-comp, meaning it is not necessary to explicitly install
 Python, NumPy, Xarray, or Dask when creating an environment and installing GeoCAT-comp.
 Although packages like Matplotlib are often used with GeoCAT-comp, they are considered
-`optional` dependencies and must be explicitly installed.
+*optional* dependencies and must be explicitly installed.
 
 If you are interested in learning more about how Conda environments work, please visit
 the [managing environments](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html)
@@ -48,7 +48,7 @@ page of the Conda documentation.
 ## Building GeoCAT-comp from source
 
 Building GeoCAT-comp from source code is a fairly straightforward task, but
-doing so should not be necessary for most users. If you are interested in
+doing so should not be necessary for most users. If you *are* interested in
 building GeoCAT-comp from source, you will need the following packages to be
 installed.
 

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -58,6 +58,7 @@ installed.
 - [GeoCAT-datafiles](https://github.com/NCAR/geocat-datafiles)  (For tests only)
 - [GeoCAT-f2py](https://github.com/NCAR/geocat-f2py)
 - [cf_xarray](https://cf-xarray.readthedocs.io/en/latest/)
+- [cftime](https://unidata.github.io/cftime/)
 - [eofs](https://ajdawson.github.io/eofs/latest/index.html)
 - [dask](https://dask.org/)
 - [distributed](https://distributed.readthedocs.io/en/latest/)

--- a/build_envs/environment.yml
+++ b/build_envs/environment.yml
@@ -5,6 +5,7 @@ channels:
 dependencies:
   - python
   - cf_xarray>=0.3.1
+  - cftime
   - dask
   - distributed
   - eofs

--- a/build_envs/environment.yml
+++ b/build_envs/environment.yml
@@ -13,7 +13,7 @@ dependencies:
   - geocat-f2py
   - metpy
   - netcdf4  # for tests
-  - numpy=1.19.0
+  - numpy
   - pip
   - pytest  # for tests
   - pytest-cov  # for tests

--- a/build_envs/environment.yml
+++ b/build_envs/environment.yml
@@ -13,7 +13,7 @@ dependencies:
   - geocat-f2py
   - metpy
   - netcdf4  # for tests
-  - numpy
+  - numpy=1.20.2
   - pip
   - pytest  # for tests
   - pytest-cov  # for tests

--- a/build_envs/upstream-dev-environment.yml
+++ b/build_envs/upstream-dev-environment.yml
@@ -4,6 +4,7 @@ channels:
   - ncar
 dependencies:
   - python
+  - cftime
   - dask
   - distributed
   - eofs

--- a/docs/conda_environment.yml
+++ b/docs/conda_environment.yml
@@ -4,6 +4,7 @@ channels:
 dependencies:
   - python
   - cf_xarray>=0.3.1
+  - cftime
   - dask
   - distributed
   - eofs

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,6 +1,10 @@
 Installation
 ============
 
+This installation guide includes only the GeoCAT-comp installation and build instructions.
+Please refer to `GeoCAT Contributor's Guide <https://geocat.ucar.edu/pages/contributing.html>`_ for installation of
+the whole GeoCAT project.
+
 Installing GeoCAT-comp via Conda
 --------------------------------
 
@@ -14,29 +18,29 @@ activated using::
 
     conda activate geocat
 
-Example code provided with this documentation frequently makes use of other
-software packages, such as Matplotlib, Cartopy, PyNGL, and Jupyter, which you
-may wish to install into your geocat environment.  The following `conda create`
-command can be used to create a new conda environment that includes some of
-these additional commonly used Python packages pre-installed::
+If you somewhat need to make use of other software packages, such as Matplotlib,
+Cartopy, Jupyter, etc. with GeoCAT-comp, you may wish to install into your :code:`geocat`
+environment.  The following :code:`conda create` command can be used to create a new
+:code:`conda` environment that includes some of these additional commonly used Python
+packages pre-installed::
 
-    conda create -n geocat -c conda-forge -c ncar geocat-comp pyngl matplotlib cartopy jupyter
+    conda create -n geocat -c conda-forge -c ncar geocat-comp matplotlib cartopy jupyter
 
 Alternatively, if you already created a conda environment using the first
 command (without the extra packages), you can activate and install the packages
 in an existing environment with the following commands::
 
     conda activate geocat # or whatever your environment is called
-    conda install -c conda-forge pyngl matplotlib cartopy jupyter
+    conda install -c conda-forge matplotlib cartopy jupyter
 
-Please note that the use of the conda-forge channel is essential to guarantee
+Please note that the use of the :code:`conda-forge` channel is essential to guarantee
 compatibility between dependency packages.
 
 Also, note that the Conda package manager automatically installs all `required`
-dependencies, meaning it is not necessary to explicitly install Python, NumPy,
-Xarray, or Dask when creating an envionment.  Although packages like Matplotlib
-are often used with GeoCAT-comp, they are considered `optional` dependencies and
-must be explicitly installed.
+dependencies of GeoCAT-comp, meaning it is not necessary to explicitly install
+Python, NumPy, Xarray, or Dask when creating an envionment and installing GeoCAT-comp.
+Although packages like Matplotlib are often used with GeoCAT-comp, they are considered
+`optional` dependencies and must be explicitly installed.
 
 If you are interested in learning more about how Conda environments work, please
 visit the `managing environments <https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html>`_
@@ -51,29 +55,34 @@ doing so should not be necessary for most users. If you `are` interested in
 building GeoCAT-comp from source, you will need the following packages to be
 installed.
 
-Required dependencies for building GeoCAT-comp
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Required dependencies for building and testing GeoCAT-comp
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-    - Python 3.5+
-    - numpy
-    - xarray
-    - cython
-    - dask
-    - pytest
-    - `ncomp <http://github.com/NCAR/ncomp/>`_
-    - Any C compiler (GCC, Clang, etc)
+    - Python 3.7+
+    - `GeoCAT-datafiles <https://github.com/NCAR/geocat-datafiles>`_  (For tests only)
+    - `GeoCAT-f2py <https://github.com/NCAR/geocat-f2py>`_
+    - `cf_xarray <https://cf-xarray.readthedocs.io/en/latest/>`_
+    - `cftime <https://unidata.github.io/cftime/>`_
+    - `eofs <https://ajdawson.github.io/eofs/latest/index.html>`_
+    - `dask <https://dask.org/>`_
+    - `distributed <https://distributed.readthedocs.io/en/latest/>`_
+    - `netcdf4 <https://unidata.github.io/netcdf4-python/>`_  (For tests only)
+    - `numpy <https://numpy.org/doc/stable/>`_
+    - `pytest <https://docs.pytest.org/en/stable/>`_  (For tests only)
+    - `xarray <http://xarray.pydata.org/en/stable/>`_
+
+Note: `GeoCAT-f2py <https://github.com/NCAR/geocat-f2py>`_ dependency will automatically
+install further dependencies for compiled language implementation.
 
 
 How to create a Conda environment for building GeoCAT-comp
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The GeoCAT-comp source code includes two Conda environment definition files in
-the `build_envs` directory that can be used to create a development environment
-containing all of the packages required to build GeoCAT-comp.  The file
-`environment_Linux.yml` is intended to be used on Linux systems, while
-`environment_Darwin.yml` should be used on macOS.  It is necessary to have
-separate `environment_*.yml` files because Linux and macOS use different C
-compilers, although the following commands should work on both Linux and macOS::
+The GeoCAT-comp source code includes a conda environment definition file in
+the :code:`/build_envs` folder under the root directory that can be used to create a
+development environment containing all of the packages required to build GeoCAT-comp.
+The file :code:`environment.yml` is intended to be used on Linux systems and macOS.
+The following commands should work on both Linux and macOS::
 
     conda env create -f build_envs/environment.yml
     conda activate geocat_comp_build
@@ -83,23 +92,20 @@ Installing GeoCAT-comp
 ^^^^^^^^^^^^^^^^^^^^^^
 
 Once the dependencies listed above are installed, you can install GeoCAT-comp
-with the command::
+with running the following command from the root-directory::
 
     pip install .
 
-If you are using a conda environment as described above, this command should
-work as-is.  However, if you have chosen to use a different Python binary and
-have installed dependencies elsewhere, you may need to set certain environment
-variables (CFLAGS, CPPFLAGS, or LDFLAGS) in order for the setup.py script to
-find all of the necessary dependency packages.  Due to the potentially
-complicated nature of the build process, we strongly recommend using Conda to
-configure your build environment.
+For compatibility purposes, we strongly recommend using Conda to
+configure your build environment as described above.
 
 
 Testing a GeoCAT-comp build
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 A GeoCAT-comp build can be tested from the root directory of the source code
-repository using the following command::
+repository using the following command (Explicit installation of the
+`pytest <https://docs.pytest.org/en/stable/>`_ package may be required, please
+see above)::
 
     pytest test

--- a/meta.yaml
+++ b/meta.yaml
@@ -24,6 +24,7 @@ requirements:
   run:
     - python
     - cf_xarray>=0.3.1
+    - cftime
     - dask
     - eofs
     - geocat-f2py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 cf_xarray>=0.3.1
+cftime
 dask[array]
 eofs
 geocat-f2py

--- a/src/geocat/comp/climatology.py
+++ b/src/geocat/comp/climatology.py
@@ -1,11 +1,8 @@
 import typing
 
 import cf_xarray
-import cftime
 import numpy as np
 import xarray as xr
-import pandas as pd
-import warnings
 
 xr.set_options(keep_attrs=True)
 

--- a/src/geocat/comp/skewt_params.py
+++ b/src/geocat/comp/skewt_params.py
@@ -62,6 +62,7 @@ def showalter_index(pressure, temperature, dewpt):
 
     # Calculate the Showalter index
     shox = Tp500 - ml
+
     return shox
 
 

--- a/test/test_skewt_params.py
+++ b/test/test_skewt_params.py
@@ -2,6 +2,7 @@ import sys
 
 import metpy.calc as mpcalc
 import numpy as np
+import numpy.testing as nt
 from metpy.units import units
 
 # Import from directory structure if coverage test, or from installed
@@ -23,10 +24,8 @@ def test_showalter_index():
 
     result = showalter_index(p, tc, tdc)
     expected = 21.353962321924012 * units.delta_degree_Celsius
-    if result == expected:
-        pass
-    else:
-        raise Exception
+
+    nt.assert_equal(result, expected)
 
 
 def test_get_skewt_vars():
@@ -34,7 +33,4 @@ def test_get_skewt_vars():
     result = get_skewt_vars(p, tc, tdc, pro)
     expected = 'Plcl= 747 Tlcl[C]= 6 Shox= 21 Pwat[cm]= 5 Cape[J]= 0'
 
-    if result == expected:
-        pass
-    else:
-        raise Exception
+    nt.assert_equal(result, expected)

--- a/test/test_skewt_params.py
+++ b/test/test_skewt_params.py
@@ -25,7 +25,7 @@ def test_showalter_index():
     result = showalter_index(p, tc, tdc)
     expected = 21.353962321924012 * units.delta_degree_Celsius
 
-    nt.assert_equal(result, expected)
+    nt.assert_almost_equal(result, expected, 4)
 
 
 def test_get_skewt_vars():
@@ -33,4 +33,4 @@ def test_get_skewt_vars():
     result = get_skewt_vars(p, tc, tdc, pro)
     expected = 'Plcl= 747 Tlcl[C]= 6 Shox= 21 Pwat[cm]= 5 Cape[J]= 0'
 
-    nt.assert_equal(result, expected)
+    nt.assert_almost_equal(result, expected, 4)

--- a/test/test_skewt_params.py
+++ b/test/test_skewt_params.py
@@ -23,9 +23,9 @@ pro = mpcalc.parcel_profile(p, tc[0], tdc[0])  # Parcel Profile
 def test_showalter_index():
 
     result = showalter_index(p, tc, tdc)
-    expected = 21.353962321924012 * units.delta_degree_Celsius
+    expected = 21.35395610431048 * units.delta_degree_Celsius
 
-    nt.assert_almost_equal(result, expected, 4)
+    nt.assert_equal(result, expected)
 
 
 def test_get_skewt_vars():
@@ -33,4 +33,4 @@ def test_get_skewt_vars():
     result = get_skewt_vars(p, tc, tdc, pro)
     expected = 'Plcl= 747 Tlcl[C]= 6 Shox= 21 Pwat[cm]= 5 Cape[J]= 0'
 
-    nt.assert_almost_equal(result, expected, 4)
+    nt.assert_equal(result, expected)


### PR DESCRIPTION
The latest geocat-comp conda releases (v2021.8.0) has `cftime` as a dependency, but it isn't listed in `meta.yml` or the other build and documentation files. This PR addresses this issue.

Files to change:
- [x] build/environment.yml
- [x] build/upstream-dev-environment.yml
- [x] docs/conda_environment.yml
- [x] docs/installation.rst
- [x] INSTALLATION.md
- [x] meta.yaml
- [x] requirements.txt

In addition, this PR fixes a testing issue with `test_skewt_params.py`, which appeared after MetPy's 1.1.0 release.