### PR TITLE
Set up Google Analytics for RTD documentation page

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,0 +1,14 @@
+{% extends "!layout.html" %}
+
+{% block extrahead %}
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-TYWFW2KJSP"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+
+        gtag('config', 'G-TYWFW2KJSP');
+    </script>
+    {{ super() }}
+{% endblock %}


### PR DESCRIPTION
This PR adds `docs/_templates/layout.html` that refers to a Google Analytics tracking ID to track analytics for https://geocat-comp.readthedocs.io/en/latest/