### PR TITLE
Make margins dynamically resize in docs

### DIFF
--- a/docs/_static/theme_overrides.css
+++ b/docs/_static/theme_overrides.css
@@ -1,0 +1,4 @@
+/* delete margin from side of content */
+.wy-nav-content {
+    max-width: none !important;
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -260,3 +260,8 @@ html_static_path = ['_static']
 htmlhelp_basename = 'geocat-compdoc'
 
 autodoc_typehints = 'none'
+
+
+# Allow for changes to be made to the css in the theme_overrides file
+def setup(app):
+    app.add_css_file('theme_overrides.css')


### PR DESCRIPTION
Erin figured out how to get the documentation for geocat-viz to dynamically resize, so this PR integrates [her findings](https://github.com/NCAR/geocat-viz/compare/populate_docs) into geocat-comp. Now the margin on the right hand side is smaller, and the documentation utilizes the entire screen space. Below are some examples of how the website looks now.

On my 27 inch 2560x1440 external monitor
![image](https://user-images.githubusercontent.com/42781301/137190136-96c12cca-94af-4c00-8460-ec984fa57bb7.png)
![image](https://user-images.githubusercontent.com/42781301/137190180-1d8a4644-5af4-46be-b603-df8cf15bf951.png)

On my 16 inch 3072x1920 built in monitor 
![image](https://user-images.githubusercontent.com/42781301/137190949-19a7a3da-4555-4fd8-a88a-ae262ed5a1be.png)
![image](https://user-images.githubusercontent.com/42781301/137190812-704fc0e3-8615-41e4-b707-429c20f82871.png)
