### PR TITLE
Try mamba to fix RTD build failures

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,6 +10,12 @@ build:
   tools:
     python: "mambaforge-4.10"
 
+python:
+   version: 3.8
+   install:
+      - method: pip
+        path: .
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/conf.py

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,11 +5,6 @@
 # Required
 version: 2
 
-build:
-  os: "ubuntu-20.04"
-  tools:
-    python: "mambaforge-4.10"
-
 python:
    install:
       - method: pip

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,7 +11,6 @@ build:
     python: "mambaforge-4.10"
 
 python:
-   version: 3.8
    install:
       - method: pip
         path: .

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,6 +5,11 @@
 # Required
 version: 2
 
+build:
+  os: "ubuntu-20.04"
+  tools:
+    python: "mambaforge-4.10"
+
 python:
    install:
       - method: pip

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,11 +5,10 @@
 # Required
 version: 2
 
-python:
-   version: 3.8
-   install:
-      - method: pip
-        path: .
+build:
+  os: "ubuntu-20.04"
+  tools:
+    python: "mambaforge-4.10"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/docs/conda_environment.yml
+++ b/docs/conda_environment.yml
@@ -13,5 +13,6 @@ dependencies:
   - metpy
   - netcdf4  # for tests
   - numpy
+  - pip
   - pytest  # for tests
   - xarray


### PR DESCRIPTION
A "failed due to excessive memory" case started here similar to one we saw recently for GeoCAT-examples. 

I attempted to fix this one with mamba as well, and it seems to have worked. 

Please see RTD build [here](https://readthedocs.org/projects/geocat-comp/builds/15907422/).