### PR TITLE
Fix Build tests timing out issue

### DIFF
--- a/src/geocat/comp/interpolation.py
+++ b/src/geocat/comp/interpolation.py
@@ -287,7 +287,8 @@ def interp_sigma_to_hybrid(data: xr.DataArray,
 
         for idx, (d, s) in enumerate(zip(data_stacked, sigma_stacked)):
             output[idx, :] = xr.DataArray(
-                _vertical_remap(func_interpolate, s, sig_coords, d))
+                _vertical_remap(func_interpolate, s.data, sig_coords.data,
+                                d.data))
 
         # Make output shape same as data shape
         output = output.unstack().transpose(*data.dims)
@@ -296,7 +297,8 @@ def interp_sigma_to_hybrid(data: xr.DataArray,
 
         output = data[:len(hyam)].copy()
         output[:len(hyam)] = xr.DataArray(
-            _vertical_remap(func_interpolate, sigma, sig_coords, data))
+            _vertical_remap(func_interpolate, sigma.data, sig_coords.data,
+                            data.data))
 
     # Set output dims and coords
     output = output.rename({lev_dim: 'hlev'})

--- a/src/geocat/comp/polynomial.py
+++ b/src/geocat/comp/polynomial.py
@@ -123,7 +123,7 @@ def ndpolyfit(x: typing.Iterable,
 
         >>> import numpy as np
         >>> from geocat.comp.polynomial import ndpolyfit
-        >>> x = np.arange(10, dtype=np.float)
+        >>> x = np.arange(10, dtype=float)
         >>> y = 2*x + 3
         >>> p = ndpolyfit(x, y, deg=1)
         >>> print(p)
@@ -187,7 +187,7 @@ def ndpolyfit(x: typing.Iterable,
 
         >>> import numpy as np
         >>> from geocat.comp.polynomial import ndpolyfit
-        >>> x = np.arange(10, dtype=np.float)
+        >>> x = np.arange(10, dtype=float)
         >>> y = 4*x*x + 3*x + 2
         >>> y[7:] = np.nan
         >>> print(y)
@@ -766,9 +766,9 @@ def detrend(data: typing.Iterable, deg=1, axis=0, **kwargs) -> xr.DataArray:
 
     x = kwargs.get("x", None)
     if x is None:
-        x = np.arange(data_shape[axis], dtype=np.float)
+        x = np.arange(data_shape[axis], dtype=float)
     elif not isinstance(x, np.ndarray):
-        x = np.asarray(x).astype(np.float)
+        x = np.asarray(x).astype(float)
 
     x = x.reshape((-1,))
 

--- a/test/test_polynomial.py
+++ b/test/test_polynomial.py
@@ -18,38 +18,38 @@ else:
 class test_internal_ndpolyfit(TestCase):
 
     def test_01(self):
-        x = np.arange(10).astype(dtype=np.float)
-        y = np.arange(10).astype(dtype=np.float)
+        x = np.arange(10).astype(dtype=float)
+        y = np.arange(10).astype(dtype=float)
 
         p = _ndpolyfit(x, y)
 
         np.testing.assert_almost_equal(p, [1.0, 0.0])
 
     def test_02(self):
-        x = np.arange(10).astype(dtype=np.float).reshape((-1, 1))
-        y = np.arange(10).astype(dtype=np.float)
+        x = np.arange(10).astype(dtype=float).reshape((-1, 1))
+        y = np.arange(10).astype(dtype=float)
 
         p = _ndpolyfit(x, y)
 
         np.testing.assert_almost_equal(p, [1.0, 0.0])
 
     def test_03(self):
-        x = np.arange(10).astype(dtype=np.float).reshape((1, -1))
-        y = np.arange(10).astype(dtype=np.float)
+        x = np.arange(10).astype(dtype=float).reshape((1, -1))
+        y = np.arange(10).astype(dtype=float)
 
         p = _ndpolyfit(x, y)
 
         np.testing.assert_almost_equal(p, [1.0, 0.0])
 
     def test_04(self):
-        x = np.arange(10).astype(dtype=np.float).reshape((2, 5))
-        y = np.arange(10).astype(dtype=np.float)
+        x = np.arange(10).astype(dtype=float).reshape((2, 5))
+        y = np.arange(10).astype(dtype=float)
 
         with self.assertRaises(ValueError):
             p = _ndpolyfit(x, y)
 
     def test_05(self):
-        x = np.arange(10).astype(dtype=np.float)
+        x = np.arange(10).astype(dtype=float)
         for i in range(50):
             expected_p = np.random.randint(-10, 10, size=2)
             while expected_p[0] == 0:
@@ -62,8 +62,8 @@ class test_internal_ndpolyfit(TestCase):
             np.testing.assert_almost_equal(expected_p, actual_p)
 
     def test_06(self):
-        x = np.arange(-10, 10).astype(dtype=np.float)
-        y = np.arange(-10, 10).astype(dtype=np.float)
+        x = np.arange(-10, 10).astype(dtype=float)
+        y = np.arange(-10, 10).astype(dtype=float)
 
         y = np.moveaxis(np.tile(y, (4, 3, 1)), 2, 0)
 
@@ -75,8 +75,8 @@ class test_internal_ndpolyfit(TestCase):
         np.testing.assert_almost_equal(actual_p, expected_p)
 
     def test_07(self):
-        x = np.arange(-10, 10).astype(dtype=np.float)
-        y = np.arange(-10, 10).astype(dtype=np.float)
+        x = np.arange(-10, 10).astype(dtype=float)
+        y = np.arange(-10, 10).astype(dtype=float)
 
         axis = 1
         y = np.moveaxis(np.tile(y, (4, 3, 1)), 2, axis)
@@ -89,8 +89,8 @@ class test_internal_ndpolyfit(TestCase):
         np.testing.assert_almost_equal(actual_p, expected_p)
 
     def test_08(self):
-        x = np.arange(-10, 10).astype(dtype=np.float)
-        y = np.arange(-10, 10).astype(dtype=np.float)
+        x = np.arange(-10, 10).astype(dtype=float)
+        y = np.arange(-10, 10).astype(dtype=float)
 
         axis = 1
         y = np.moveaxis(np.tile(y, (4, 3, 1)), 2, axis)
@@ -103,7 +103,7 @@ class test_internal_ndpolyfit(TestCase):
         np.testing.assert_almost_equal(actual_p, expected_p)
 
     def test_09(self):
-        x = np.arange(-10, 10).astype(dtype=np.float)
+        x = np.arange(-10, 10).astype(dtype=float)
         max_dim = 6
         max_dim_size = 11
 
@@ -126,8 +126,8 @@ class test_internal_ndpolyfit(TestCase):
             np.testing.assert_almost_equal(expected_p, actual_p)
 
     def test_10(self):
-        x = np.arange(10).astype(dtype=np.float)
-        y = np.arange(10).astype(dtype=np.float)
+        x = np.arange(10).astype(dtype=float)
+        y = np.arange(10).astype(dtype=float)
 
         y[5] = np.nan
         p = _ndpolyfit(x, y)
@@ -135,8 +135,8 @@ class test_internal_ndpolyfit(TestCase):
         np.testing.assert_almost_equal(p, [1.0, 0.0])
 
     def test_11(self):
-        x = np.arange(10).astype(dtype=np.float)
-        y = np.arange(10).astype(dtype=np.float)
+        x = np.arange(10).astype(dtype=float)
+        y = np.arange(10).astype(dtype=float)
 
         for i in range(20):
             idx = np.random.randint(0, 10)
@@ -146,7 +146,7 @@ class test_internal_ndpolyfit(TestCase):
             np.testing.assert_almost_equal(p, [1.0, 0.0])
 
     def test_12(self):
-        x = np.arange(10).astype(dtype=np.float)
+        x = np.arange(10).astype(dtype=float)
         for i in range(50):
             expected_p = np.random.randint(-10, 10, size=2)
             while expected_p[0] == 0:
@@ -159,9 +159,9 @@ class test_internal_ndpolyfit(TestCase):
             np.testing.assert_almost_equal(expected_p, actual_p)
 
     def test_13(self):
-        x = np.arange(10).astype(dtype=np.float)
-        y = np.concatenate((np.arange(10).astype(dtype=np.float).reshape(
-            (-1, 1)), np.arange(10).astype(dtype=np.float).reshape((-1, 1))),
+        x = np.arange(10).astype(dtype=float)
+        y = np.concatenate((np.arange(10).astype(dtype=float).reshape(
+            (-1, 1)), np.arange(10).astype(dtype=float).reshape((-1, 1))),
                            axis=1)
 
         y[4, 0] = np.nan
@@ -170,9 +170,9 @@ class test_internal_ndpolyfit(TestCase):
         np.testing.assert_almost_equal(p, [[1.0, 1.0], [0.0, 0.0]])
 
     def test_14(self):
-        x = np.arange(10).astype(dtype=np.float)
-        y = np.concatenate((np.arange(10).astype(dtype=np.float).reshape(
-            (-1, 1)), np.arange(10).astype(dtype=np.float).reshape((-1, 1))),
+        x = np.arange(10).astype(dtype=float)
+        y = np.concatenate((np.arange(10).astype(dtype=float).reshape(
+            (-1, 1)), np.arange(10).astype(dtype=float).reshape((-1, 1))),
                            axis=1)
 
         y[4, :] = np.nan
@@ -181,7 +181,7 @@ class test_internal_ndpolyfit(TestCase):
         np.testing.assert_almost_equal(p, [[1.0, 1.0], [0.0, 0.0]])
 
     def test_15(self):
-        x = np.arange(-10, 10).astype(dtype=np.float)
+        x = np.arange(-10, 10).astype(dtype=float)
         max_dim = 6
         max_dim_size = 11
 
@@ -205,9 +205,9 @@ class test_internal_ndpolyfit(TestCase):
             np.testing.assert_almost_equal(expected_p, actual_p)
 
     def test_16(self):
-        x = np.arange(10).astype(dtype=np.float)
-        y = np.concatenate((np.arange(10).astype(dtype=np.float).reshape(
-            (-1, 1)), np.arange(10).astype(dtype=np.float).reshape((-1, 1))),
+        x = np.arange(10).astype(dtype=float)
+        y = np.concatenate((np.arange(10).astype(dtype=float).reshape(
+            (-1, 1)), np.arange(10).astype(dtype=float).reshape((-1, 1))),
                            axis=1)
 
         p = _ndpolyfit(x, y, missing_value=5)
@@ -217,32 +217,32 @@ class test_internal_ndpolyfit(TestCase):
 class test_ndpolyfit(TestCase):
 
     def test_00(self):
-        x = np.arange(10).astype(dtype=np.float).tolist()
-        y = np.arange(10).astype(dtype=np.float).tolist()
+        x = np.arange(10).astype(dtype=float).tolist()
+        y = np.arange(10).astype(dtype=float).tolist()
 
         p = ndpolyfit(x, y, deg=1)
 
         np.testing.assert_almost_equal(p, [1.0, 0.0])
 
     def test_01(self):
-        x = np.arange(10).astype(dtype=np.float)
-        y = np.arange(10).astype(dtype=np.float)
+        x = np.arange(10).astype(dtype=float)
+        y = np.arange(10).astype(dtype=float)
 
         p = ndpolyfit(x, y, deg=1)
 
         np.testing.assert_almost_equal(p, [1.0, 0.0])
 
     def test_02(self):
-        x = xr.DataArray(np.arange(10).astype(dtype=np.float))
-        y = xr.DataArray(np.arange(10).astype(dtype=np.float))
+        x = xr.DataArray(np.arange(10).astype(dtype=float))
+        y = xr.DataArray(np.arange(10).astype(dtype=float))
 
         p = ndpolyfit(x, y, deg=1)
 
         np.testing.assert_almost_equal(p, [1.0, 0.0])
 
     def test_03(self):
-        x = xr.DataArray(np.arange(10).astype(dtype=np.float))
-        y = xr.DataArray(np.arange(10).astype(dtype=np.float))
+        x = xr.DataArray(np.arange(10).astype(dtype=float))
+        y = xr.DataArray(np.arange(10).astype(dtype=float))
         y.attrs["attr1"] = 1
         y.attrs["attr2"] = 2
 
@@ -256,8 +256,8 @@ class test_ndpolyfit(TestCase):
         self.assertEqual(2, p.attrs["attr2"])
 
     def test_04(self):
-        x = xr.DataArray(np.arange(10).astype(dtype=np.float))
-        y = xr.DataArray(np.arange(10).astype(dtype=np.float))
+        x = xr.DataArray(np.arange(10).astype(dtype=float))
+        y = xr.DataArray(np.arange(10).astype(dtype=float))
         y.attrs["attr1"] = 1
         y.attrs["attr2"] = 2
 
@@ -269,17 +269,17 @@ class test_ndpolyfit(TestCase):
         self.assertFalse("attr2" in p.attrs)
 
     def test_05(self):
-        x = np.arange(10).astype(dtype=np.float)
-        y = np.arange(10).astype(dtype=np.float)
+        x = np.arange(10).astype(dtype=float)
+        y = np.arange(10).astype(dtype=float)
 
         p = ndpolyfit(x, y, deg=1, meta=False)
 
         np.testing.assert_almost_equal(p, [1.0, 0.0])
 
     def test_6(self):
-        x = np.arange(10).astype(dtype=np.float)
-        y = np.concatenate((np.arange(10).astype(dtype=np.float).reshape(
-            (-1, 1)), np.arange(10).astype(dtype=np.float).reshape((-1, 1))),
+        x = np.arange(10).astype(dtype=float)
+        y = np.concatenate((np.arange(10).astype(dtype=float).reshape(
+            (-1, 1)), np.arange(10).astype(dtype=float).reshape((-1, 1))),
                            axis=1)
 
         y[5, :] = 999
@@ -288,7 +288,7 @@ class test_ndpolyfit(TestCase):
         np.testing.assert_almost_equal(p, [[1.0, 1.0], [0.0, 0.0]])
 
     def test_7(self):
-        x = xr.DataArray(np.arange(-10, 10).astype(dtype=np.float))
+        x = xr.DataArray(np.arange(-10, 10).astype(dtype=float))
         max_dim = 6
         max_dim_size = 11
 
@@ -313,7 +313,7 @@ class test_ndpolyfit(TestCase):
             np.testing.assert_almost_equal(expected_p, actual_p)
 
     def test_8(self):
-        x = xr.DataArray(np.arange(-10, 10).astype(dtype=np.float))
+        x = xr.DataArray(np.arange(-10, 10).astype(dtype=float))
         max_dim = 3
         max_dim_size = 5
 


### PR DESCRIPTION
Essentially fixes the build tests timing out issue through addressing "UserWarning: Passing an object to dask.array.from_array which is already a Dask collection. This can lead to unexpected behavior." in `interpolation.py`.

PR also fixes "np.float Deprecated" warnings in `meteorology.py` and `test_meteorology.py` files