### PR TITLE
Use np.ufuncs instead of xr.ufuncs

### DIFF
--- a/docs/user_api/index.rst
+++ b/docs/user_api/index.rst
@@ -70,6 +70,12 @@ GeoCAT-comp native routines
 
    geocat.comp.skewt_params.showalter_index
 
+   geocat.comp.spherical.decomposition
+
+   geocat.comp.spherical.recomposition
+
+   geocat.comp.spherical.scale_voronoi
+
 
 GeoCAT-comp routines from GeoCAT-f2py
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/geocat/comp/__init__.py
+++ b/src/geocat/comp/__init__.py
@@ -13,7 +13,7 @@ from .interpolation import interp_hybrid_to_pressure, interp_sigma_to_hybrid
 from .polynomial import detrend, ndpolyfit, ndpolyval
 from .meteorology import dewtemp, heat_index, relhum, relhum_ice, relhum_water
 from .skewt_params import get_skewt_vars, showalter_index
-from .spherical import harmonic_decomposition, harmonic_recomposition
+from .spherical import decomposition, recomposition, scale_voronoi
 
 # bring all functions from geocat.f2py into the geocat.comp namespace
 try:

--- a/src/geocat/comp/meteorology.py
+++ b/src/geocat/comp/meteorology.py
@@ -118,16 +118,16 @@ def _heat_index(temperature: np.ndarray,
 
         # adjustments
         heatindex = xr.where(
-            xr.ufuncs.logical_and(
+            np.ufuncs.logical_and(
                 relative_humidity < 13,
-                xr.ufuncs.logical_and(temperature > 80, temperature < 112)),
+                np.ufuncs.logical_and(temperature > 80, temperature < 112)),
             heatindex - ((13 - relative_humidity) / 4) * np.sqrt(
                 (17 - abs(temperature - 95)) / 17), heatindex)
 
         heatindex = xr.where(
-            xr.ufuncs.logical_and(
+            np.ufuncs.logical_and(
                 relative_humidity > 85,
-                xr.ufuncs.logical_and(temperature > 80, temperature < 87)),
+                np.ufuncs.logical_and(temperature > 80, temperature < 87)),
             heatindex + ((relative_humidity - 85.0) / 10.0) *
             ((87.0 - temperature) / 5.0), heatindex)
 
@@ -468,16 +468,16 @@ def _xheat_index(temperature: xr.DataArray,
 
         # adjustments
         heatindex = xr.where(
-            xr.ufuncs.logical_and(
+            np.ufuncs.logical_and(
                 relative_humidity < 13,
-                xr.ufuncs.logical_and(temperature > 80, temperature < 112)),
+                np.ufuncs.logical_and(temperature > 80, temperature < 112)),
             heatindex - ((13 - relative_humidity) / 4) * np.sqrt(
                 (17 - abs(temperature - 95)) / 17), heatindex)
 
         heatindex = xr.where(
-            xr.ufuncs.logical_and(
+            np.ufuncs.logical_and(
                 relative_humidity > 85,
-                xr.ufuncs.logical_and(temperature > 80, temperature < 87)),
+                np.ufuncs.logical_and(temperature > 80, temperature < 87)),
             heatindex + ((relative_humidity - 85.0) / 10.0) *
             ((87.0 - temperature) / 5.0), heatindex)
 

--- a/src/geocat/comp/spherical.py
+++ b/src/geocat/comp/spherical.py
@@ -32,7 +32,7 @@ def harmonic_decomposition(
     scale0 = 1 / (np.sum(input_scale, axis=(0, 1)) * ss.sph_harm(0, 0, 0, 0)**2)
     scale0 = scale0.compute().persist()
     scale1 = scale0 * 2
-    input_data_scaled = np.multiply(demo_data, input_scale).persist()
+    input_data_scaled = np.multiply(input_data, input_scale).persist()
     for harm in harms:
         results.append(
             np.sum(np.multiply(

--- a/src/geocat/comp/spherical.py
+++ b/src/geocat/comp/spherical.py
@@ -114,8 +114,7 @@ def recomposition(
         phi = xr.DataArray(phi, dims=phi.dims).chunk((chunk_size))
         data = xr.DataArray(data, dims=['har']).chunk((chunk_size))
 
-    results = \
-        np.sum(
+    results = np.sum(
         np.multiply(sspecial.sph_harm(m, n, theta, phi).real, data.real),
         axis=(0),
     ) + np.sum(

--- a/src/geocat/comp/spherical.py
+++ b/src/geocat/comp/spherical.py
@@ -67,14 +67,22 @@ def decomposition(
         m = xr.DataArray(m, dims=['har']).chunk((chunk_size))
         n = xr.DataArray(n, dims=['har']).chunk((chunk_size))
         scale_mul = xr.DataArray(scale_mul, dims=['har']).chunk((chunk_size))
-        scale_dat = xr.DataArray(np.multiply(data, scale),
-                                 dims=data.dims).chunk((chunk_size))
+        scale_dat = xr.DataArray(
+            np.multiply(data, scale),
+            dims=data.dims,
+        ).chunk((chunk_size))
         theta = xr.DataArray(theta, dims=data.dims).chunk((chunk_size))
         phi = xr.DataArray(phi, dims=data.dims).chunk((chunk_size))
 
-    results = np.sum(np.multiply(scale_dat, sspecial.sph_harm(m, n, theta,
-                                                              phi)),
-                     axis=(0, 1)) * scale_mul * scale_val
+    results = np.sum(
+        np.multiply(scale_dat, sspecial.sph_harm(
+            m,
+            n,
+            theta,
+            phi,
+        )),
+        axis=(0, 1),
+    ) * scale_mul * scale_val
     return results
 
 
@@ -114,7 +122,12 @@ def recomposition(
     results = np.sum(np.multiply(
         sspecial.sph_harm(m, n, theta, phi).real, data.real),
                      axis=(0)) + np.sum(np.multiply(
-                         sspecial.sph_harm(m, n, theta, phi).imag, data.imag),
+                         sspecial.sph_harm(
+                             m,
+                             n,
+                             theta,
+                             phi,
+                         ).imag, data.imag),
                                         axis=(0))
 
     return results.real

--- a/src/geocat/comp/spherical.py
+++ b/src/geocat/comp/spherical.py
@@ -40,19 +40,19 @@ def harmonic_decomposition(
         n = np.expand_dims(n, axis=(0, 1))
         theta = np.expand_dims(theta, axis=(2))
         phi = np.expand_dims(phi, axis=(2))
-        data_scaled = np.expand_dims(np.multiply(data, scale), axis=(2))
+        scale_dat = np.expand_dims(np.multiply(data, scale), axis=(2))
 
     # if xarray, set dims and chunks for broadcast in ss.sphere_harm
     if type(data) is xr.DataArray:
         m = xr.DataArray(m, dims=['har']).chunk((chunk_size))
         n = xr.DataArray(n, dims=['har']).chunk((chunk_size))
         scale_mul = xr.DataArray(scale_mul, dims=['har']).chunk((chunk_size))
-        data_scaled = xr.DataArray(np.multiply(data, scale),
-                                   dims=data.dims).chunk((chunk_size))
+        scale_dat = xr.DataArray(np.multiply(data, scale),
+                                 dims=data.dims).chunk((chunk_size))
         theta = xr.DataArray(theta, dims=data.dims).chunk((chunk_size))
         phi = xr.DataArray(phi, dims=data.dims).chunk((chunk_size))
 
-    results = np.sum(np.multiply(data_scaled, ss.sph_harm(m, n, theta, phi)),
+    results = np.sum(np.multiply(scale_dat, ss.sph_harm(m, n, theta, phi)),
                      axis=(0, 1)) * scale_mul * scale_val
     return results
 
@@ -79,6 +79,7 @@ def harmonic_recomposition(
     if type(data) is np.ndarray:
         m = np.expand_dims(m, axis=(1, 2))
         n = np.expand_dims(n, axis=(1, 2))
+        data = np.expand_dims(data, axis=(1, 2))
         theta = np.expand_dims(theta, axis=(0))
         phi = np.expand_dims(phi, axis=(0))
 

--- a/src/geocat/comp/spherical.py
+++ b/src/geocat/comp/spherical.py
@@ -135,10 +135,11 @@ def scale_voronoi(
     data_locs_3d[:, 0] = np.sin(phi_1d) * np.sin(theta_1d)
     data_locs_3d[:, 1] = np.sin(phi_1d) * np.cos(theta_1d)
     data_locs_3d[:, 2] = np.cos(phi_1d)
-    sv = sspatial.SphericalVoronoi(data_locs_3d,
-                                   radius=1.0,
-                                   center=np.array([0, 0, 0]))
-    scale = np.array(sv.calculate_areas()).reshape(theta.shape)
+    scale = np.array(
+        sspatial.SphericalVoronoi(data_locs_3d,
+                                  radius=1.0,
+                                  center=np.array([0, 0,
+                                                   0]))).reshape(theta.shape)
     if type(theta) is xr.DataArray:
         scale = xr.DataArray(scale, dims=theta.dims).chunk(chunk_size)
     return scale

--- a/src/geocat/comp/spherical.py
+++ b/src/geocat/comp/spherical.py
@@ -44,9 +44,8 @@ def harmonic_decomposition(
         m = xr.DataArray(m, dims=['har']).chunk((chunk_size))
         n = xr.DataArray(n, dims=['har']).chunk((chunk_size))
         input_data_scaled = \
-            xr.DataArray(input_data_scaled,
-                                         dims=['lat', 'lon']).chunk(
-                                             (chunk_size))
+            xr.DataArray( \
+                input_data_scaled, dims=['lat', 'lon']).chunk((chunk_size))
         theta = xr.DataArray(theta, dims=['lat', 'lon']).chunk((chunk_size))
         phi = xr.DataArray(phi, dims=['lat', 'lon']).chunk((chunk_size))
 

--- a/src/geocat/comp/spherical.py
+++ b/src/geocat/comp/spherical.py
@@ -48,12 +48,8 @@ def harmonic_decomposition(
         theta = xr.DataArray(theta, dims=['lat', 'lon']).chunk((chunk_size))
         phi = xr.DataArray(phi, dims=['lat', 'lon']).chunk((chunk_size))
 
-    results = \
-        np.sum(
-            np.multiply(
-                data_scaled,
-                ss.sph_harm(m, n, theta, phi)),
-            axis=(0, 1))
+    results = np.sum(np.multiply(data_scaled, ss.sph_harm(m, n, theta, phi)),
+                     axis=(0, 1))
     # results = results * scale0
 
     # return same data type as input

--- a/src/geocat/comp/spherical.py
+++ b/src/geocat/comp/spherical.py
@@ -190,22 +190,12 @@ def scale_voronoi(
 
     Parameters
     ----------
-    data : :class:`numpy.ndarray`, :class:`xarray.DataArray`
-        1-dimensional array of spherical harmonics.
-        These must by in the same order output by geocat.comp.spherical.decomposition.
-
     theta : :class:`numpy.ndarray`, :class:`xarray.DataArray`
         2-dimensional array containing the theta (longitude in radians) values for each datapoint in data.
 
     phi : :class:`numpy.ndarray`, :class:`xarray.DataArray`
         2-dimensional array containing the theta (latitude in radians) values for each datapoint in data.
         Phi is zero at the top of the sphere and pi at the bottom, phi = (lat_degrees-90)*(-1)*pi/180
-
-    max_harm: :class: `int`, Optional
-        The maximum harmonic value for both m and n.
-        The total of harmonics calculated is (max_harm+1)*(max_harm+2)/2
-        The number of total harmonics must equal the number of harmoncs in the input data.
-        Defaults to 23, for 300 total harmonics.
 
     chunk_size: :class: `int`, Optional
         The size of the each edge of the dask chunks if using xarray.DataArray inputs.
@@ -216,7 +206,7 @@ def scale_voronoi(
     Returns
     -------
     scale : :class:`numpy.ndarray`, :class:`xarray.DataArray`
-        2-dimensional array containing the area of the spherical voronoi cell for each theta phi pair.
+        2-dimensional array containing the area of the spherical voronoi cell for each theta and phi pair.
     """
 
     if type(theta) is xr.DataArray:

--- a/src/geocat/comp/spherical.py
+++ b/src/geocat/comp/spherical.py
@@ -16,7 +16,6 @@ def harmonic_decomposition(
     max_harm: int = default_max_harm,
     chunk_size: dict = {},
 ) -> SupportedTypes:
-
     scale_val = 1 / (np.sum(scale, axis=(0, 1)) * ss.sph_harm(0, 0, 0, 0)**2)
     scale_mul = []
     mlist = []
@@ -64,7 +63,6 @@ def harmonic_recomposition(
     max_harm: int = default_max_harm,
     chunk_size: dict = {},
 ) -> SupportedTypes:
-
     mlist = []
     nlist = []
     for nvalue in range(max_harm + 1):
@@ -91,6 +89,9 @@ def harmonic_recomposition(
         phi = xr.DataArray(phi, dims=phi.dims).chunk((chunk_size))
         data = xr.DataArray(data, dims=['har']).chunk((chunk_size))
 
-    results = np.sum(np.multiply(ss.sph_harm(m, n, theta, phi), data), axis=(0))
+    results = np.sum(np.multiply(ss.sph_harm(m, n, theta, phi).real, data.real),
+                     axis=(0)) + np.sum(np.multiply(
+                         ss.sph_harm(m, n, theta, phi).imag, data.imag),
+                                        axis=(0))
 
     return results.real

--- a/src/geocat/comp/spherical.py
+++ b/src/geocat/comp/spherical.py
@@ -20,7 +20,7 @@ def harmonic_decomposition(
     mlist = []
     nlist = []
     for nvalue in range(max_harm + 1):
-        for mvalue in range(n + 1):
+        for mvalue in range(nvalue + 1):
             mlist.append(mvalue)
             nlist.append(nvalue)
 
@@ -50,14 +50,6 @@ def harmonic_decomposition(
 
     results = np.sum(np.multiply(data_scaled, ss.sph_harm(m, n, theta, phi)),
                      axis=(0, 1))
-    # results = results * scale0
-
-    # return same data type as input
-
-    # if type(input_data) is np.array:
-    #     results = np.asarray(results)
-    # if type(input_data) is xr.DataArray:
-    #     results = xr.DataArray(results)
     return results
 
 

--- a/src/geocat/comp/spherical.py
+++ b/src/geocat/comp/spherical.py
@@ -223,7 +223,7 @@ def scale_voronoi(
             data_locs_3d,
             radius=1.0,
             center=np.array([0, 0, 0]),
-        )).reshape(theta.shape)
+        ).calculate_areas()).reshape(theta.shape)
 
     if type(theta) is xr.DataArray:
         scale = xr.DataArray(scale, dims=theta.dims).chunk(chunk_size)

--- a/src/geocat/comp/spherical.py
+++ b/src/geocat/comp/spherical.py
@@ -48,7 +48,8 @@ def harmonic_decomposition(
         n = xr.DataArray(n, dims=['har']).chunk((chunk_size))
         scale_mul = xr.DataArray(scale_mul, dims=['har']).chunk((chunk_size))
         data_scaled = \
-            xr.DataArray(np.multiply(data, scale), dims=data.dims).chunk((chunk_size))
+            xr.DataArray(np.multiply(data, scale),
+                         dims=data.dims).chunk((chunk_size))
         theta = xr.DataArray(theta, dims=data.dims).chunk((chunk_size))
         phi = xr.DataArray(phi, dims=data.dims).chunk((chunk_size))
 

--- a/src/geocat/comp/spherical.py
+++ b/src/geocat/comp/spherical.py
@@ -44,7 +44,7 @@ def harmonic_decomposition(
         m = xr.DataArray(m, dims=['har']).chunk((chunk_size))
         n = xr.DataArray(n, dims=['har']).chunk((chunk_size))
         data_scaled = \
-            xr.DataArray(data_scaled,dims=['lat', 'lon']).chunk((chunk_size))
+            xr.DataArray(data_scaled, dims=['lat', 'lon']).chunk((chunk_size))
         theta = xr.DataArray(theta, dims=['lat', 'lon']).chunk((chunk_size))
         phi = xr.DataArray(phi, dims=['lat', 'lon']).chunk((chunk_size))
 

--- a/src/geocat/comp/spherical.py
+++ b/src/geocat/comp/spherical.py
@@ -91,6 +91,6 @@ def harmonic_recomposition(
         phi = xr.DataArray(phi, dims=phi.dims).chunk((chunk_size))
         data = xr.DataArray(data, dims=['har']).chunk((chunk_size))
 
-    results = np.sum(np.multiply(data, ss.sph_harm(m, n, theta, phi)), axis=(0))
+    results = np.sum(np.multiply(ss.sph_harm(m, n, theta, phi), data), axis=(0))
 
     return results.real

--- a/src/geocat/comp/spherical.py
+++ b/src/geocat/comp/spherical.py
@@ -29,7 +29,7 @@ def harmonic_decomposition(
     theta = theta
     phi = phi
     scale0 = 1 / (np.sum(scale, axis=(0, 1)) * ss.sph_harm(0, 0, 0, 0)**2)
-    input_data_scaled = np.multiply(data, scale)
+    data_scaled = np.multiply(data, scale)
 
     # if numpy, change dimensions to allow for broadcast in ss.sph_harm
     if type(data) is np.array:
@@ -37,24 +37,21 @@ def harmonic_decomposition(
         n = np.expand_dims(n, axis=(0, 1))
         theta = np.expand_dims(theta, axis=(2))
         phi = np.expand_dims(phi, axis=(2))
-        input_data_scaled = np.expand_dims(input_data_scaled, axis=(2))
+        data_scaled = np.expand_dims(data_scaled, axis=(2))
 
     # if xarray, set dims and chunks for
     if type(data) is xr.DataArray:
         m = xr.DataArray(m, dims=['har']).chunk((chunk_size))
         n = xr.DataArray(n, dims=['har']).chunk((chunk_size))
-        input_data_scaled = \
-            xr.DataArray(
-                input_data_scaled,
-                dims=['lat', 'lon']
-            ).chunk((chunk_size))
+        data_scaled = \
+            xr.DataArray(data_scaled,dims=['lat', 'lon']).chunk((chunk_size))
         theta = xr.DataArray(theta, dims=['lat', 'lon']).chunk((chunk_size))
         phi = xr.DataArray(phi, dims=['lat', 'lon']).chunk((chunk_size))
 
     results = \
         np.sum(
             np.multiply(
-                input_data_scaled,
+                data_scaled,
                 ss.sph_harm(m, n, theta, phi)),
             axis=(0, 1))
     # results = results * scale0

--- a/src/geocat/comp/spherical.py
+++ b/src/geocat/comp/spherical.py
@@ -114,11 +114,13 @@ def recomposition(
         phi = xr.DataArray(phi, dims=phi.dims).chunk((chunk_size))
         data = xr.DataArray(data, dims=['har']).chunk((chunk_size))
 
-    results = np.sum(np.multiply(
-        sspecial.sph_harm(m, n, theta, phi).real, data.real),
-                     axis=(0)) + np.sum(np.multiply(
-                         sspecial.sph_harm(m, n, theta, phi).imag, data.imag),
-                                        axis=(0))
+    results = np.sum(
+        np.multiply(sspecial.sph_harm(m, n, theta, phi).real, data.real),
+        axis=(0),
+    ) + np.sum(
+        np.multiply(sspecial.sph_harm(m, n, theta, phi).imag, data.imag),
+        axis=(0),
+    )
 
     return results.real
 

--- a/src/geocat/comp/spherical.py
+++ b/src/geocat/comp/spherical.py
@@ -45,7 +45,7 @@ def decomposition(
         The size of the each edge of the dask chunks if using xarray.DataArray inputs.
         Some arrays will be 2d, and others 1d, and the final calculation operates on a 3d array.
         thus the chunks used in the largest calculation scale at chunk_size^3
-        A chunk size of 256 is reccomended. Defaults to 'auto'
+        A chunk size of 256 is recommended. Defaults to 'auto'
 
     Returns
     -------
@@ -134,7 +134,7 @@ def recomposition(
         The size of the each edge of the dask chunks if using xarray.DataArray inputs.
         Some arrays will be 2d, and others 1d, and the final calculation operates on a 3d array.
         thus the chunks used in the largest calculation scale at chunk_size^3
-        A chunk size of 256 is reccomended. Defaults to 'auto'
+        A chunk size of 256 is recommended. Defaults to 'auto'
 
     Returns
     -------
@@ -198,7 +198,7 @@ def scale_voronoi(
         The size of the each edge of the dask chunks if using xarray.DataArray inputs.
         Some arrays will be 2d, and others 1d, and the final calculation operates on a 3d array.
         thus the chunks used in the largest calculation scale at chunk_size^3
-        A chunk size of 256 is reccomended. Defaults to 'auto'
+        A chunk size of 256 is recommended. Defaults to 'auto'
 
     Returns
     -------

--- a/src/geocat/comp/spherical.py
+++ b/src/geocat/comp/spherical.py
@@ -43,7 +43,8 @@ def harmonic_decomposition(
     if type(data) is xr.DataArray:
         m = xr.DataArray(m, dims=['har']).chunk((chunk_size))
         n = xr.DataArray(n, dims=['har']).chunk((chunk_size))
-        input_data_scaled = xr.DataArray(input_data_scaled,
+        input_data_scaled = \
+            xr.DataArray(input_data_scaled,
                                          dims=['lat', 'lon']).chunk(
                                              (chunk_size))
         theta = xr.DataArray(theta, dims=['lat', 'lon']).chunk((chunk_size))

--- a/src/geocat/comp/spherical.py
+++ b/src/geocat/comp/spherical.py
@@ -30,12 +30,12 @@ def harmonic_decomposition(
 
     results = []
     scale0 = 1 / (np.sum(input_scale, axis=(0, 1)) * ss.sph_harm(0, 0, 0, 0)**2)
-    if input_scale is xr.DataArray:
-        scale0 = scale0.compute().persist()
+    # if input_scale is xr.DataArray:
+    #     scale0 = scale0.persist()
     scale1 = scale0 * 2
     input_data_scaled = np.multiply(input_data, input_scale)
-    if input_data is xr.DataArray:
-        input_data_scaled = input_data_scaled.persist()
+    # if input_data is xr.DataArray:
+    #     input_data_scaled = input_data_scaled.persist()
 
     for harm in harms:
         results.append(
@@ -83,4 +83,4 @@ def harmonic_recomposition(
         sphere = ss.sph_harm(harm[0], harm[1], input_theta, input_phi)
         results += sphere.real * value.real + sphere.imag * value.imag
 
-    return results
+    return results.real

--- a/src/geocat/comp/spherical.py
+++ b/src/geocat/comp/spherical.py
@@ -117,12 +117,7 @@ def recomposition(
     results = np.sum(np.multiply(
         sspecial.sph_harm(m, n, theta, phi).real, data.real),
                      axis=(0)) + np.sum(np.multiply(
-                         sspecial.sph_harm(
-                             m,
-                             n,
-                             theta,
-                             phi,
-                         ).imag, data.imag),
+                         sspecial.sph_harm(m, n, theta, phi).imag, data.imag),
                                         axis=(0))
 
     return results.real

--- a/src/geocat/comp/spherical.py
+++ b/src/geocat/comp/spherical.py
@@ -29,7 +29,7 @@ def harmonic_decomposition(
                 harms.append([m, n])
 
     results = []
-    scale0 = 1 / (np.sum(scale_phi, axis=(0, 1)) * ss.sph_harm(0, 0, 0, 0)**2)
+    scale0 = 1 / (np.sum(input_scale, axis=(0, 1)) * ss.sph_harm(0, 0, 0, 0)**2)
     scale0 = scale0.compute().persist()
     scale1 = scale0 * 2
     input_data_scaled = np.multiply(demo_data, input_scale).persist()

--- a/src/geocat/comp/spherical.py
+++ b/src/geocat/comp/spherical.py
@@ -114,7 +114,8 @@ def recomposition(
         phi = xr.DataArray(phi, dims=phi.dims).chunk((chunk_size))
         data = xr.DataArray(data, dims=['har']).chunk((chunk_size))
 
-    results = np.sum(
+    results = \
+        np.sum(
         np.multiply(sspecial.sph_harm(m, n, theta, phi).real, data.real),
         axis=(0),
     ) + np.sum(

--- a/src/geocat/comp/spherical.py
+++ b/src/geocat/comp/spherical.py
@@ -5,7 +5,7 @@ import scipy.special as ss
 import xarray as xr
 
 DataA = Union[np.array, xr.DataArray]
-Harms = Union[list[list], DataA]
+Harms = Union[list[list], np.array, xr.DataArray]
 default_max_harm = 23  # 300 harmonics from 0,0 to 23,23
 
 

--- a/src/geocat/comp/spherical.py
+++ b/src/geocat/comp/spherical.py
@@ -9,7 +9,7 @@ SupportedTypes = Union[np.ndarray, xr.DataArray]
 default_max_harm = 23  # 300 harmonics from 0,0 to 23,23
 
 
-def harmonic_decomposition(
+def decomposition(
     data: SupportedTypes,
     scale: SupportedTypes,
     theta: SupportedTypes,
@@ -36,7 +36,8 @@ def harmonic_decomposition(
         the spherical harmonic decomposition of the input data
     """
 
-    scale_val = 1 / (np.sum(scale, axis=(0, 1)) * ss.sph_harm(0, 0, 0, 0)**2)
+    scale_val = 1 / (np.sum(scale, axis=(0, 1)) *
+                     sspecial.sph_harm(0, 0, 0, 0)**2)
     scale_mul = []
     mlist = []
     nlist = []
@@ -77,7 +78,7 @@ def harmonic_decomposition(
     return results
 
 
-def harmonic_recomposition(
+def recomposition(
     data: SupportedTypes,
     theta: SupportedTypes,
     phi: SupportedTypes,
@@ -113,7 +114,7 @@ def harmonic_recomposition(
     results = np.sum(np.multiply(
         sspecial.sph_harm(m, n, theta, phi).real, data.real),
                      axis=(0)) + np.sum(np.multiply(
-                         ss.sph_harm(m, n, theta, phi).imag, data.imag),
+                         sspecial.sph_harm(m, n, theta, phi).imag, data.imag),
                                         axis=(0))
 
     return results.real
@@ -124,8 +125,12 @@ def scale_voronoi(
     phi: SupportedTypes,
     chunk_size: dict = {},
 ) -> SupportedTypes:
-    theta_1d = theta_np.reshape((theta.shape[0] * theta.shape[1],))
-    phi_1d = phi_np.reshape((phi.shape[0] * phi.shape[1],))
+    if type(theta) is xr.DataArray:
+        theta = theta.to_numpy()
+        phi = phi.to_numpy()
+
+    theta_1d = theta.reshape((theta.shape[0] * theta.shape[1],))
+    phi_1d = phi.reshape((phi.shape[0] * phi.shape[1],))
     data_locs_3d = np.zeros((len(phi_1d), 3))
     data_locs_3d[:, 0] = np.sin(phi_1d) * np.sin(theta_1d)
     data_locs_3d[:, 1] = np.sin(phi_1d) * np.cos(theta_1d)

--- a/src/geocat/comp/spherical.py
+++ b/src/geocat/comp/spherical.py
@@ -75,12 +75,7 @@ def decomposition(
         phi = xr.DataArray(phi, dims=data.dims).chunk((chunk_size))
 
     results = np.sum(
-        np.multiply(scale_dat, sspecial.sph_harm(
-            m,
-            n,
-            theta,
-            phi,
-        )),
+        np.multiply(scale_dat, sspecial.sph_harm(m, n, theta, phi)),
         axis=(0, 1),
     ) * scale_mul * scale_val
     return results

--- a/src/geocat/comp/spherical.py
+++ b/src/geocat/comp/spherical.py
@@ -30,9 +30,13 @@ def harmonic_decomposition(
 
     results = []
     scale0 = 1 / (np.sum(input_scale, axis=(0, 1)) * ss.sph_harm(0, 0, 0, 0)**2)
-    scale0 = scale0.compute().persist()
+    if input_scale is xr.DataArray:
+        scale0 = scale0.compute().persist()
     scale1 = scale0 * 2
-    input_data_scaled = np.multiply(input_data, input_scale).persist()
+    input_data_scaled = np.multiply(input_data, input_scale)
+    if input_data is xr.DataArray:
+        input_data_scaled = input_data_scaled.persist()
+
     for harm in harms:
         results.append(
             np.sum(np.multiply(

--- a/src/geocat/comp/spherical.py
+++ b/src/geocat/comp/spherical.py
@@ -44,8 +44,10 @@ def harmonic_decomposition(
         m = xr.DataArray(m, dims=['har']).chunk((chunk_size))
         n = xr.DataArray(n, dims=['har']).chunk((chunk_size))
         input_data_scaled = \
-            xr.DataArray( \
-                input_data_scaled, dims=['lat', 'lon']).chunk((chunk_size))
+            xr.DataArray(
+                input_data_scaled,
+                dims=['lat', 'lon']
+            ).chunk((chunk_size))
         theta = xr.DataArray(theta, dims=['lat', 'lon']).chunk((chunk_size))
         phi = xr.DataArray(phi, dims=['lat', 'lon']).chunk((chunk_size))
 

--- a/src/geocat/comp/spherical.py
+++ b/src/geocat/comp/spherical.py
@@ -4,19 +4,18 @@ import numpy as np
 import scipy.special as ss
 import xarray as xr
 
-DataA = Union[np.array, xr.DataArray]
-Harms = Union[list[list], np.array, xr.DataArray]
+SupportedTypes = Union[np.array, xr.DataArray]
 default_max_harm = 23  # 300 harmonics from 0,0 to 23,23
 
 
 def harmonic_decomposition(
-    input_data: DataA,
-    input_scale: DataA,
-    input_theta: DataA,
-    input_phi: DataA,
-    harms: Harms = None,
+    input_data: SupportedTypes,
+    input_scale: SupportedTypes,
+    input_theta: SupportedTypes,
+    input_phi: SupportedTypes,
+    harms: SupportedTypes = None,
     max_harm: int = None,
-) -> DataA:
+) -> SupportedTypes:
     # if no harmonic info provided by the user:
     if max_harm is None and harms is None:
         max_harm = default_max_harm
@@ -56,12 +55,12 @@ def harmonic_decomposition(
 
 
 def harmonic_recomposition(
-    input_data: DataA,
-    input_theta: DataA,
-    input_phi: DataA,
-    harms: Harms = None,
+    input_data: SupportedTypes,
+    input_theta: SupportedTypes,
+    input_phi: SupportedTypes,
+    harms: SupportedTypes = None,
     max_harm: int = None,
-) -> DataA:
+) -> SupportedTypes:
     # if no harmonic info provided by the user:
     if max_harm is None and harms is None:
         max_harm = default_max_harm

--- a/src/geocat/comp/spherical.py
+++ b/src/geocat/comp/spherical.py
@@ -46,15 +46,14 @@ def harmonic_decomposition(
     if type(data) is xr.DataArray:
         m = xr.DataArray(m, dims=['har']).chunk((chunk_size))
         n = xr.DataArray(n, dims=['har']).chunk((chunk_size))
-        scale_multiplier = xr.DataArray(scale_results, dims=['har']).chunk(
-            (chunk_size))
+        scale_mul = xr.DataArray(scale_mul, dims=['har']).chunk((chunk_size))
         data_scaled = \
             xr.DataArray(data_scaled, dims=['lat', 'lon']).chunk((chunk_size))
         theta = xr.DataArray(theta, dims=['lat', 'lon']).chunk((chunk_size))
         phi = xr.DataArray(phi, dims=['lat', 'lon']).chunk((chunk_size))
 
     results = np.sum(np.multiply(data_scaled, ss.sph_harm(m, n, theta, phi)),
-                     axis=(0, 1))  #*scale1
+                     axis=(0, 1)) * scale_mul * scale_val
     return results
 
 

--- a/src/geocat/comp/spherical.py
+++ b/src/geocat/comp/spherical.py
@@ -15,7 +15,7 @@ def decomposition(
     theta: SupportedTypes,
     phi: SupportedTypes,
     max_harm: int = default_max_harm,
-    chunk_size: dict = {},
+    chunk_size: int = 'auto',
 ) -> SupportedTypes:
     """Calculate the spherical harmonics of a dataset. This function allows for
     the use of any 2d grid.
@@ -41,6 +41,12 @@ def decomposition(
         The maximum harmonic value for both m and n.
         The total of harmonics calculated is (max_harm+1)*(max_harm+2)/2
         Defaults to 23, for 300 total harmonics.
+
+    chunk_size: :class: `int`, Optional
+        The size of the each edge of the dask chunks if using xarray.DataArray inputs.
+        Some arrays will be 2d, and others 1d, and the final calculation operates on a 3d array.
+        thus the chunks used in the largest calculation scale at chunk_size^3
+        A chunk size of 256 is reccomended. Defaults to 'auto'
 
     Returns
     -------
@@ -102,8 +108,41 @@ def recomposition(
     theta: SupportedTypes,
     phi: SupportedTypes,
     max_harm: int = default_max_harm,
-    chunk_size: dict = {},
+    chunk_size: int = 'auto',
 ) -> SupportedTypes:
+    """Calculate a dataset from spherical harmonics. This function allows for
+    the use of any 2d grid.
+
+    Parameters
+    ----------
+    data : :class:`numpy.ndarray`, :class:`xarray.DataArray`
+        1-dimensional array of spherical harmonics.
+        These must by in the same order output by geocat.comp.spherical.decomposition.
+
+    theta : :class:`numpy.ndarray`, :class:`xarray.DataArray`
+        2-dimensional array containing the theta (longitude in radians) values for each datapoint in data.
+
+    phi : :class:`numpy.ndarray`, :class:`xarray.DataArray`
+        2-dimensional array containing the theta (latitude in radians) values for each datapoint in data.
+        Phi is zero at the top of the sphere and pi at the bottom, phi = (lat_degrees-90)*(-1)*pi/180
+
+    max_harm: :class: `int`, Optional
+        The maximum harmonic value for both m and n.
+        The total of harmonics calculated is (max_harm+1)*(max_harm+2)/2
+        The number of total harmonics must equal the number of harmoncs in the input data.
+        Defaults to 23, for 300 total harmonics.
+
+    chunk_size: :class: `int`, Optional
+        The size of the each edge of the dask chunks if using xarray.DataArray inputs.
+        Some arrays will be 2d, and others 1d, and the final calculation operates on a 3d array.
+        thus the chunks used in the largest calculation scale at chunk_size^3
+        A chunk size of 256 is reccomended. Defaults to 'auto'
+
+    Returns
+    -------
+    recomposition : :class:`numpy.ndarray`, :class:`xarray.DataArray`
+        the spherical harmonic recomposition of the input data
+    """
 
     mlist = []
     nlist = []
@@ -144,8 +183,41 @@ def recomposition(
 def scale_voronoi(
     theta: SupportedTypes,
     phi: SupportedTypes,
-    chunk_size: dict = {},
+    chunk_size: int = 'auto',
 ) -> SupportedTypes:
+    """Calculate a dataset from spherical harmonics. This function allows for
+    the use of any 2d grid.
+
+    Parameters
+    ----------
+    data : :class:`numpy.ndarray`, :class:`xarray.DataArray`
+        1-dimensional array of spherical harmonics.
+        These must by in the same order output by geocat.comp.spherical.decomposition.
+
+    theta : :class:`numpy.ndarray`, :class:`xarray.DataArray`
+        2-dimensional array containing the theta (longitude in radians) values for each datapoint in data.
+
+    phi : :class:`numpy.ndarray`, :class:`xarray.DataArray`
+        2-dimensional array containing the theta (latitude in radians) values for each datapoint in data.
+        Phi is zero at the top of the sphere and pi at the bottom, phi = (lat_degrees-90)*(-1)*pi/180
+
+    max_harm: :class: `int`, Optional
+        The maximum harmonic value for both m and n.
+        The total of harmonics calculated is (max_harm+1)*(max_harm+2)/2
+        The number of total harmonics must equal the number of harmoncs in the input data.
+        Defaults to 23, for 300 total harmonics.
+
+    chunk_size: :class: `int`, Optional
+        The size of the each edge of the dask chunks if using xarray.DataArray inputs.
+        Some arrays will be 2d, and others 1d, and the final calculation operates on a 3d array.
+        thus the chunks used in the largest calculation scale at chunk_size^3
+        A chunk size of 256 is reccomended. Defaults to 'auto'
+
+    Returns
+    -------
+    scale : :class:`numpy.ndarray`, :class:`xarray.DataArray`
+        2-dimensional array containing the area of the spherical voronoi cell for each theta phi pair.
+    """
 
     if type(theta) is xr.DataArray:
         theta = theta.to_numpy()

--- a/src/geocat/comp/spherical.py
+++ b/src/geocat/comp/spherical.py
@@ -53,11 +53,17 @@ def decomposition(
         the spherical harmonic decomposition of the input data
     """
 
+    # scale_val is the inverse of the total sphere area times the magnitude of
+    # the first harmoninc. This is used to scale the output so that the output
+    # is unaffected by the surface area of the original sphere.
     scale_val = 1 / (np.sum(scale, axis=(0, 1)) *
                      sspecial.sph_harm(0, 0, 0, 0)**2)
 
-    mlist = []
-    nlist = []
+    mlist = []  # ordered list of the m harmonics sspecial.sphere(m,n,theta,phi)
+    nlist = []  # ordered list of the n harmonics sspecial.sphere(m,n,theta,phi)
+    # the real value of the output varies on a factor of two when m is 0,
+    # due to m=0 being a symmetric case with no imaginary component,
+    # this accounts for that difference in output sum.
     scale_mul = []
     for nvalue in range(max_harm + 1):
         for mvalue in range(nvalue + 1):
@@ -142,8 +148,8 @@ def recomposition(
         the spherical harmonic recomposition of the input data
     """
 
-    mlist = []
-    nlist = []
+    mlist = []  # ordered list of the m harmonics sspecial.sphere(m,n,theta,phi)
+    nlist = []  # ordered list of the n harmonics sspecial.sphere(m,n,theta,phi)
     for nvalue in range(max_harm + 1):
         for mvalue in range(nvalue + 1):
             mlist.append(mvalue)

--- a/src/geocat/comp/spherical.py
+++ b/src/geocat/comp/spherical.py
@@ -17,8 +17,7 @@ def decomposition(
     max_harm: int = default_max_harm,
     chunk_size: int = 'auto',
 ) -> SupportedTypes:
-    """Calculate the spherical harmonics of a dataset. This function allows for
-    the use of any 2d grid.
+    """Calculate the spherical harmonics of a dataset.
 
     Parameters
     ----------
@@ -110,8 +109,7 @@ def recomposition(
     max_harm: int = default_max_harm,
     chunk_size: int = 'auto',
 ) -> SupportedTypes:
-    """Calculate a dataset from spherical harmonics. This function allows for
-    the use of any 2d grid.
+    """Calculate a dataset from spherical harmonics.
 
     Parameters
     ----------
@@ -185,8 +183,7 @@ def scale_voronoi(
     phi: SupportedTypes,
     chunk_size: int = 'auto',
 ) -> SupportedTypes:
-    """Calculate a dataset from spherical harmonics. This function allows for
-    the use of any 2d grid.
+    """Calculate the area weighting for dataset.
 
     Parameters
     ----------

--- a/src/geocat/comp/spherical.py
+++ b/src/geocat/comp/spherical.py
@@ -122,6 +122,7 @@ def harmonic_recomposition(
 def scale_voronoi(
     theta: SupportedTypes,
     phi: SupportedTypes,
+    chunk_size: dict = {},
 ) -> SupportedTypes:
     theta_1d = theta_np.reshape((theta.shape[0] * theta.shape[1],))
     phi_1d = phi_np.reshape((phi.shape[0] * phi.shape[1],))

--- a/src/geocat/comp/spherical.py
+++ b/src/geocat/comp/spherical.py
@@ -47,9 +47,8 @@ def harmonic_decomposition(
         m = xr.DataArray(m, dims=['har']).chunk((chunk_size))
         n = xr.DataArray(n, dims=['har']).chunk((chunk_size))
         scale_mul = xr.DataArray(scale_mul, dims=['har']).chunk((chunk_size))
-        data_scaled = \
-            xr.DataArray(np.multiply(data, scale),
-                         dims=data.dims).chunk((chunk_size))
+        data_scaled = xr.DataArray(np.multiply(data, scale),
+                                   dims=data.dims).chunk((chunk_size))
         theta = xr.DataArray(theta, dims=data.dims).chunk((chunk_size))
         phi = xr.DataArray(phi, dims=data.dims).chunk((chunk_size))
 

--- a/src/geocat/comp/spherical.py
+++ b/src/geocat/comp/spherical.py
@@ -136,10 +136,11 @@ def scale_voronoi(
     data_locs_3d[:, 1] = np.sin(phi_1d) * np.cos(theta_1d)
     data_locs_3d[:, 2] = np.cos(phi_1d)
     scale = np.array(
-        sspatial.SphericalVoronoi(data_locs_3d,
-                                  radius=1.0,
-                                  center=np.array([0, 0,
-                                                   0]))).reshape(theta.shape)
+        sspatial.SphericalVoronoi(
+            data_locs_3d,
+            radius=1.0,
+            center=np.array([0, 0, 0]),
+        )).reshape(theta.shape)
     if type(theta) is xr.DataArray:
         scale = xr.DataArray(scale, dims=theta.dims).chunk(chunk_size)
     return scale

--- a/test/test_spherical.py
+++ b/test/test_spherical.py
@@ -14,25 +14,28 @@ from src.geocat.comp import harmonic_decomposition, harmonic_recomposition
 #     from geocat.comp import harmonic_decomposition, harmonic_recomposition
 
 max_harm = 23
-num_phi = 1000
-num_theta = 2000
-chunkshape = (500, 500)
+num_phi = 360
+num_theta = 720
+data_chunkshape = (180, 180)
+results_chunkshape = (100,)
 
-phi = np.linspace(ma.pi / (2 * num_phi), ma.pi - ma.pi / (2 * num_phi), num_phi)
 theta = np.linspace(0, ma.tau - ma.tau / num_theta, num_theta)
+phi = np.linspace(ma.pi / (2 * num_phi), ma.pi - ma.pi / (2 * num_phi), num_phi)
 theta_np, phi_np = np.meshgrid(theta, phi)
 # phi_coord = np.linspace(90-90/num_phi, 90/num_phi-90, num_phi)
 # theta_coord = np.linspace(0, 360-360/num_theta, num_theta)
-theta_xr = xr.DataArray(theta_np, dims=['lat', 'lon']).chunk(chunkshape)
-phi_xr = xr.DataArray(phi_np, dims=['lat', 'lon']).chunk(chunkshape)
+theta_xr = xr.DataArray(theta_np, dims=['lat', 'lon']).chunk(data_chunkshape)
+phi_xr = xr.DataArray(phi_np, dims=['lat', 'lon']).chunk(data_chunkshape)
 scale_phi_np = np.sin(phi_np)  # area weighting for data points.
-scale_phi_xr = xr.DataArray(scale_phi_np, dims=['lat', 'lon']).chunk(chunkshape)
+scale_phi_xr = xr.DataArray(scale_phi_np, dims=['lat',
+                                                'lon']).chunk(data_chunkshape)
 
 test_data = np.zeros(theta_np.shape)
 test_results = []
-
+test_harmonics = []
 for n in range(max_harm + 1):
     for m in range(n + 1):
+        test_harmonics.append([m, n])
         test_results.append(0)
         if n in [0, 2, 3, 5, 7, 11, 13, 17, 19, 23
                 ] and m in [0, 2, 3, 5, 7, 11, 13, 17, 19, 23]:
@@ -43,19 +46,34 @@ for n in range(max_harm + 1):
                 test_data += ss.sph_harm(m, n, theta_np, phi_np).real
                 test_results[-1] = 1
 
+test_harmonics_np = np.array(test_harmonics)
 test_data_np = test_data
-test_data_xr = xr.DataArray(test_data_np, dims=['lat', 'lon']).chunk(chunkshape)
-test_results_np = np.asarray(test_results)
-test_results_xr = xr.DataArray(test_results_np).chunk((100,))
-
-
-def test_decomposition_xr():
-    results_xr = harmonic_decomposition(test_data_xr, scale_phi_xr, theta_xr,
-                                        phi_xr)
-    np.testing.assert_almost_equal(results_xr, test_result_xr)
+test_data_xr = xr.DataArray(test_data_np, dims=['lat',
+                                                'lon']).chunk(data_chunkshape)
+test_results_np = np.array(test_results)
+test_results_xr = xr.DataArray(test_results_np,
+                               dims=['har']).chunk(results_chunkshape)
 
 
 def test_decomposition_np():
     results_np = harmonic_decomposition(test_data_np, scale_phi_np, theta_np,
                                         phi_np)
-    np.testing.assert_almost_equal(results_np, test_result_np)
+    np.testing.assert_almost_equal(results_np, test_results_np, decimal=3)
+
+
+def test_decomposition_xr():
+    results_xr = harmonic_decomposition(test_data_xr, scale_phi_xr, theta_xr,
+                                        phi_xr)
+    np.testing.assert_almost_equal(results_xr.data,
+                                   test_results_xr.data,
+                                   decimal=3)
+
+
+def test_recomposition_np():
+    data_np = harmonic_recomposition(test_results_np, theta_np, phi_np)
+    np.testing.assert_almost_equal(data_np, test_data_np, decimal=3)
+
+
+def test_recomposition_xr():
+    data_xr = harmonic_recomposition(test_results_xr, theta_xr, phi_xr)
+    np.testing.assert_almost_equal(data_xr.data, test_data_xr.data, decimal=3)

--- a/test/test_spherical.py
+++ b/test/test_spherical.py
@@ -5,14 +5,12 @@ import xarray as xr
 import sys
 from typing import Union
 
-from src.geocat.comp import decomposition, recomposition, scale_voronoi
-
 # Import from directory structure if coverage test, or from installed
 # packages otherwise
-# if "--cov" in str(sys.argv):
-#     from src.geocat.comp import harmonic_decomposition, harmonic_recomposition
-# else:
-#     from geocat.comp import harmonic_decomposition, harmonic_recomposition
+if "--cov" in str(sys.argv):
+    from src.geocat.comp import harmonic_decomposition, harmonic_recomposition
+else:
+    from geocat.comp import harmonic_decomposition, harmonic_recomposition
 
 max_harm = 23
 num_phi = 360

--- a/test/test_spherical.py
+++ b/test/test_spherical.py
@@ -5,12 +5,14 @@ import xarray as xr
 import sys
 from typing import Union
 
+from src.geocat.comp import harmonic_decomposition, harmonic_recomposition
+
 # Import from directory structure if coverage test, or from installed
 # packages otherwise
-if "--cov" in str(sys.argv):
-    from src.geocat.comp import harmonic_decomposition, harmonic_recomposition
-else:
-    from geocat.comp import harmonic_decomposition, harmonic_recomposition
+# if "--cov" in str(sys.argv):
+#     from src.geocat.comp import harmonic_decomposition, harmonic_recomposition
+# else:
+#     from geocat.comp import harmonic_decomposition, harmonic_recomposition
 
 max_harm = 23
 num_phi = 360
@@ -75,9 +77,9 @@ def test_decomposition_xr():
 
 def test_recomposition_np():
     data_np = harmonic_recomposition(test_results_np, theta_np, phi_np)
-    np.testing.assert_almost_equal(data_np, test_data_np, decimal=3)
+    np.testing.assert_almost_equal(data_np, test_data_np, decimal=2)
 
 
 def test_recomposition_xr():
     data_xr = harmonic_recomposition(test_results_xr, theta_xr, phi_xr)
-    np.testing.assert_almost_equal(data_xr.data, test_data_xr.data, decimal=3)
+    np.testing.assert_almost_equal(data_xr.data, test_data_xr.data, decimal=2)

--- a/test/test_spherical.py
+++ b/test/test_spherical.py
@@ -71,38 +71,69 @@ class Test_Spherical(unittest.TestCase):
         ).compute()
 
     def test_decomposition_np(self):
-        results_np = decomposition(self.test_data_np, self.test_scale_np,
-                                   self.theta_np, self.phi_np)
-        np.testing.assert_almost_equal(results_np,
-                                       self.test_results_np,
-                                       decimal=3)
+        results_np = decomposition(
+            self.test_data_np,
+            self.test_scale_np,
+            self.theta_np,
+            self.phi_np,
+        )
+        np.testing.assert_almost_equal(
+            results_np,
+            self.test_results_np,
+            decimal=3,
+        )
 
     def test_decomposition_xr(self):
-        results_xr = decomposition(self.test_data_xr, self.test_scale_xr,
-                                   self.theta_xr, self.phi_xr)
-        np.testing.assert_almost_equal(results_xr.to_numpy(),
-                                       self.test_results_xr.to_numpy(),
-                                       decimal=3)
+        results_xr = decomposition(
+            self.test_data_xr,
+            self.test_scale_xr,
+            self.theta_xr,
+            self.phi_xr,
+        )
+        np.testing.assert_almost_equal(
+            results_xr.to_numpy(),
+            self.test_results_xr.to_numpy(),
+            decimal=3,
+        )
 
     def test_recomposition_np(self):
-        data_np = recomposition(self.test_results_np, self.theta_np,
-                                self.phi_np)
-        np.testing.assert_almost_equal(data_np, self.test_data_np)
+        data_np = recomposition(
+            self.test_results_np,
+            self.theta_np,
+            self.phi_np,
+        )
+        np.testing.assert_almost_equal(
+            data_np,
+            self.test_data_np,
+        )
 
     def test_recomposition_xr(self):
-        data_xr = recomposition(self.test_results_xr, self.theta_xr,
-                                self.phi_xr)
-        np.testing.assert_almost_equal(data_xr.to_numpy(),
-                                       self.test_data_xr.to_numpy())
+        data_xr = recomposition(
+            self.test_results_xr,
+            self.theta_xr,
+            self.phi_xr,
+        )
+        np.testing.assert_almost_equal(
+            data_xr.to_numpy(),
+            self.test_data_xr.to_numpy(),
+        )
 
     def test_scale_voronoi_np(self):
-        scale_np = scale_voronoi(self.theta_np, self.phi_np)
+        scale_np = scale_voronoi(
+            self.theta_np,
+            self.phi_np,
+        )
         np.testing.assert_almost_equal(
             scale_np / np.sum(scale_np, axis=(0, 1)),
-            self.test_scale_np / np.sum(self.test_scale_np, axis=(0, 1)))
+            self.test_scale_np / np.sum(self.test_scale_np, axis=(0, 1)),
+        )
 
     def test_scale_voronoi_xr(self):
-        scale_xr = scale_voronoi(self.theta_xr, self.phi_xr)
+        scale_xr = scale_voronoi(
+            self.theta_xr,
+            self.phi_xr,
+        )
         np.testing.assert_almost_equal(
             scale_xr / np.sum(scale_xr, axis=(0, 1)),
-            self.test_scale_xr / np.sum(self.test_scale_xr, axis=(0, 1)))
+            self.test_scale_xr / np.sum(self.test_scale_xr, axis=(0, 1)),
+        )

--- a/test/test_spherical.py
+++ b/test/test_spherical.py
@@ -49,12 +49,20 @@ class Test_Spherical(unittest.TestCase):
                 if n in [0, 2, 3, 5, 7, 11, 13, 17, 19, 23
                         ] and m in [0, 2, 3, 5, 7, 11, 13, 17, 19, 23]:
                     if m in [2, 5, 11, 17, 23]:
-                        test_data += ss.sph_harm(m, n, cls.theta_np,
-                                                 cls.phi_np).imag
+                        test_data += ss.sph_harm(
+                            m,
+                            n,
+                            cls.theta_np,
+                            cls.phi_np,
+                        ).imag
                         test_results[-1] = 1j
                     else:
-                        test_data += ss.sph_harm(m, n, cls.theta_np,
-                                                 cls.phi_np).real
+                        test_data += ss.sph_harm(
+                            m,
+                            n,
+                            cls.theta_np,
+                            cls.phi_np,
+                        ).real
                         test_results[-1] = 1
 
         cls.test_harmonics_np = np.array(test_harmonics)

--- a/test/test_spherical.py
+++ b/test/test_spherical.py
@@ -33,7 +33,7 @@ class Test_Spherical(unittest.TestCase):
         cls.theta_np, cls.phi_np = np.meshgrid(theta, phi)
         cls.theta_xr = xr.DataArray(cls.theta_np, dims=['lat', 'lon'])
         cls.phi_xr = xr.DataArray(cls.phi_np, dims=['lat', 'lon'])
-        cls.test_scale_np = np.sin(phi_np)
+        cls.test_scale_np = np.sin(cls.phi_np)
         cls.test_scale_xr = xr.DataArray(
             cls.test_scale_np,
             dims=['lat', 'lon'],

--- a/test/test_spherical.py
+++ b/test/test_spherical.py
@@ -24,14 +24,19 @@ class Test_Spherical(unittest.TestCase):
         num_theta = 720
 
         theta = np.linspace(0, ma.tau - ma.tau / num_theta, num_theta)
-        phi = np.linspace(ma.pi / (2 * num_phi), ma.pi - ma.pi / (2 * num_phi),
-                          num_phi)
+        phi = np.linspace(
+            ma.pi / (2 * num_phi),
+            ma.pi - ma.pi / (2 * num_phi),
+            num_phi,
+        )
         cls.theta_np, cls.phi_np = np.meshgrid(theta, phi)
         cls.theta_xr = xr.DataArray(cls.theta_np, dims=['lat', 'lon'])
         cls.phi_xr = xr.DataArray(cls.phi_np, dims=['lat', 'lon'])
         cls.test_scale_np = np.sin(phi_np)
-        cls.test_scale_xr = xr.DataArray(cls.test_scale_np,
-                                         dims=['lat', 'lon']).compute()
+        cls.test_scale_xr = xr.DataArray(
+            cls.test_scale_np,
+            dims=['lat', 'lon'],
+        ).compute()
 
         test_data = np.zeros(cls.theta_np.shape)
         test_results = []

--- a/test/test_spherical.py
+++ b/test/test_spherical.py
@@ -3,6 +3,7 @@ import numpy as np
 import math as ma
 import xarray as xr
 import sys
+import unittest
 from typing import Union
 
 # Import from directory structure if coverage test, or from installed

--- a/test/test_spherical.py
+++ b/test/test_spherical.py
@@ -17,17 +17,13 @@ from src.geocat.comp import harmonic_decomposition, harmonic_recomposition
 max_harm = 23
 num_phi = 360
 num_theta = 720
-data_chunkshape = (180, 180)
-results_chunkshape = (100,)
 
 theta = np.linspace(0, ma.tau - ma.tau / num_theta, num_theta)
 phi = np.linspace(ma.pi / (2 * num_phi), ma.pi - ma.pi / (2 * num_phi), num_phi)
 theta_np, phi_np = np.meshgrid(theta, phi)
-# phi_coord = np.linspace(90-90/num_phi, 90/num_phi-90, num_phi)
-# theta_coord = np.linspace(0, 360-360/num_theta, num_theta)
 theta_xr = xr.DataArray(theta_np, dims=['lat', 'lon']).chunk(data_chunkshape)
 phi_xr = xr.DataArray(phi_np, dims=['lat', 'lon']).chunk(data_chunkshape)
-scale_phi_np = np.sin(phi_np)  # area weighting for data points.
+scale_phi_np = np.sin(phi_np)
 scale_phi_xr = xr.DataArray(scale_phi_np, dims=['lat',
                                                 'lon']).chunk(data_chunkshape)
 
@@ -48,29 +44,26 @@ for n in range(max_harm + 1):
                 test_results[-1] = 1
 
 test_harmonics_np = np.array(test_harmonics)
-test_harmonics_xr = xr.DataArray(test_harmonics_np,
-                                 dims=['har', 'm,n'
-                                      ]).chunk(results_chunkshape).compute()
+test_harmonics_xr = xr.DataArray(test_harmonics_np, dims=['har',
+                                                          'm,n']).compute()
 test_data_np = test_data
-test_data_xr = xr.DataArray(test_data_np,
-                            dims=['lat',
-                                  'lon']).chunk(data_chunkshape).compute()
+test_data_xr = xr.DataArray(test_data_np, dims=['lat', 'lon']).compute()
 test_results_np = np.array(test_results)
-test_results_xr = xr.DataArray(test_results_np,
-                               dims=['har'
-                                    ]).chunk(results_chunkshape).compute()
+test_results_xr = xr.DataArray(test_results_np, dims=['har']).compute()
 
 
 def test_decomposition_np():
     results_np = harmonic_decomposition(test_data_np, scale_phi_np, theta_np,
                                         phi_np)
-    np.testing.assert_almost_equal(results_np, test_results_np)
+    np.testing.assert_almost_equal(results_np, test_results_np, decimal=3)
 
 
 def test_decomposition_xr():
     results_xr = harmonic_decomposition(test_data_xr, scale_phi_xr, theta_xr,
                                         phi_xr)
-    np.testing.assert_almost_equal(results_xr.data, test_results_xr.data)
+    np.testing.assert_almost_equal(results_xr.values,
+                                   test_results_xr.values,
+                                   decimal=3)
 
 
 def test_recomposition_np():
@@ -80,4 +73,4 @@ def test_recomposition_np():
 
 def test_recomposition_xr():
     data_xr = harmonic_recomposition(test_results_xr, theta_xr, phi_xr)
-    np.testing.assert_almost_equal(data_xr.data, test_data_xr.data)
+    np.testing.assert_almost_equal(data_xr.values, test_data_xr.values)

--- a/test/test_spherical.py
+++ b/test/test_spherical.py
@@ -24,11 +24,14 @@ phi = np.linspace(ma.pi / (2 * num_phi), ma.pi - ma.pi / (2 * num_phi), num_phi)
 theta_np, phi_np = np.meshgrid(theta, phi)
 # phi_coord = np.linspace(90-90/num_phi, 90/num_phi-90, num_phi)
 # theta_coord = np.linspace(0, 360-360/num_theta, num_theta)
-theta_xr = xr.DataArray(theta_np, dims=['lat', 'lon']).chunk(data_chunkshape)
-phi_xr = xr.DataArray(phi_np, dims=['lat', 'lon']).chunk(data_chunkshape)
+theta_xr = xr.DataArray(theta_np,
+                        dims=['lat', 'lon']).chunk(data_chunkshape).persist()
+phi_xr = xr.DataArray(phi_np, dims=['lat',
+                                    'lon']).chunk(data_chunkshape).persist()
 scale_phi_np = np.sin(phi_np)  # area weighting for data points.
-scale_phi_xr = xr.DataArray(scale_phi_np, dims=['lat',
-                                                'lon']).chunk(data_chunkshape)
+scale_phi_xr = xr.DataArray(scale_phi_np,
+                            dims=['lat',
+                                  'lon']).chunk(data_chunkshape).persist()
 
 test_data = np.zeros(theta_np.shape)
 test_results = []

--- a/test/test_spherical.py
+++ b/test/test_spherical.py
@@ -24,14 +24,11 @@ phi = np.linspace(ma.pi / (2 * num_phi), ma.pi - ma.pi / (2 * num_phi), num_phi)
 theta_np, phi_np = np.meshgrid(theta, phi)
 # phi_coord = np.linspace(90-90/num_phi, 90/num_phi-90, num_phi)
 # theta_coord = np.linspace(0, 360-360/num_theta, num_theta)
-theta_xr = xr.DataArray(theta_np,
-                        dims=['lat', 'lon']).chunk(data_chunkshape).persist()
-phi_xr = xr.DataArray(phi_np, dims=['lat',
-                                    'lon']).chunk(data_chunkshape).persist()
+theta_xr = xr.DataArray(theta_np, dims=['lat', 'lon']).chunk(data_chunkshape)
+phi_xr = xr.DataArray(phi_np, dims=['lat', 'lon']).chunk(data_chunkshape)
 scale_phi_np = np.sin(phi_np)  # area weighting for data points.
-scale_phi_xr = xr.DataArray(scale_phi_np,
-                            dims=['lat',
-                                  'lon']).chunk(data_chunkshape).persist()
+scale_phi_xr = xr.DataArray(scale_phi_np, dims=['lat',
+                                                'lon']).chunk(data_chunkshape)
 
 test_data = np.zeros(theta_np.shape)
 test_results = []
@@ -50,14 +47,17 @@ for n in range(max_harm + 1):
                 test_results[-1] = 1
 
 test_harmonics_np = np.array(test_harmonics)
+test_harmonics_xr = xr.DataArray(test_harmonics_np,
+                                 dims=['har', 'm,n'
+                                      ]).chunk(results_chunkshape).compute()
 test_data_np = test_data
 test_data_xr = xr.DataArray(test_data_np,
                             dims=['lat',
-                                  'lon']).chunk(data_chunkshape).persist()
+                                  'lon']).chunk(data_chunkshape).compute()
 test_results_np = np.array(test_results)
 test_results_xr = xr.DataArray(test_results_np,
                                dims=['har'
-                                    ]).chunk(results_chunkshape).persist()
+                                    ]).chunk(results_chunkshape).compute()
 
 
 def test_decomposition_np():

--- a/test/test_spherical.py
+++ b/test/test_spherical.py
@@ -5,13 +5,12 @@ import xarray as xr
 import sys
 from typing import Union
 
-from src.geocat.comp import harmonic_decomposition, harmonic_recomposition
 # Import from directory structure if coverage test, or from installed
 # packages otherwise
-# if "--cov" in str(sys.argv):
-#     from src.geocat.comp import harmonic_decomposition, harmonic_recomposition
-# else:
-#     from geocat.comp import harmonic_decomposition, harmonic_recomposition
+if "--cov" in str(sys.argv):
+    from src.geocat.comp import harmonic_decomposition, harmonic_recomposition
+else:
+    from geocat.comp import harmonic_decomposition, harmonic_recomposition
 
 max_harm = 23
 num_phi = 360

--- a/test/test_spherical.py
+++ b/test/test_spherical.py
@@ -77,9 +77,9 @@ def test_decomposition_xr():
 
 def test_recomposition_np():
     data_np = harmonic_recomposition(test_results_np, theta_np, phi_np)
-    np.testing.assert_almost_equal(data_np, test_data_np, decimal=2)
+    np.testing.assert_almost_equal(data_np, test_data_np, decimal=3)
 
 
 def test_recomposition_xr():
     data_xr = harmonic_recomposition(test_results_xr, theta_xr, phi_xr)
-    np.testing.assert_almost_equal(data_xr.data, test_data_xr.data, decimal=2)
+    np.testing.assert_almost_equal(data_xr.data, test_data_xr.data, decimal=3)

--- a/test/test_spherical.py
+++ b/test/test_spherical.py
@@ -80,6 +80,4 @@ def test_recomposition_np():
 
 def test_recomposition_xr():
     data_xr = harmonic_recomposition(test_results_xr, theta_xr, phi_xr)
-    print(data_xr.data)
-    print(test_data_xr.data)
     np.testing.assert_almost_equal(data_xr.data, test_data_xr.data, decimal=3)

--- a/test/test_spherical.py
+++ b/test/test_spherical.py
@@ -48,11 +48,13 @@ for n in range(max_harm + 1):
 
 test_harmonics_np = np.array(test_harmonics)
 test_data_np = test_data
-test_data_xr = xr.DataArray(test_data_np, dims=['lat',
-                                                'lon']).chunk(data_chunkshape)
+test_data_xr = xr.DataArray(test_data_np,
+                            dims=['lat',
+                                  'lon']).chunk(data_chunkshape).persist()
 test_results_np = np.array(test_results)
 test_results_xr = xr.DataArray(test_results_np,
-                               dims=['har']).chunk(results_chunkshape)
+                               dims=['har'
+                                    ]).chunk(results_chunkshape).persist()
 
 
 def test_decomposition_np():
@@ -76,4 +78,6 @@ def test_recomposition_np():
 
 def test_recomposition_xr():
     data_xr = harmonic_recomposition(test_results_xr, theta_xr, phi_xr)
+    print(data_xr.data)
+    print(test_data_xr.data)
     np.testing.assert_almost_equal(data_xr.data, test_data_xr.data, decimal=3)

--- a/test/test_spherical.py
+++ b/test/test_spherical.py
@@ -9,77 +9,95 @@ from typing import Union
 # packages otherwise
 if "--cov" in str(sys.argv):
     from src.geocat.comp import decomposition, recomposition, scale_voronoi
+elif "-v" in str(sys.argv):
+    from src.geocat.comp import decomposition, recomposition, scale_voronoi
 else:
     from geocat.comp import decomposition, recomposition, scale_voronoi
 
-max_harm = 23
-num_phi = 360
-num_theta = 720
 
-theta = np.linspace(0, ma.tau - ma.tau / num_theta, num_theta)
-phi = np.linspace(ma.pi / (2 * num_phi), ma.pi - ma.pi / (2 * num_phi), num_phi)
-theta_np, phi_np = np.meshgrid(theta, phi)
-theta_xr = xr.DataArray(theta_np, dims=['lat', 'lon'])
-phi_xr = xr.DataArray(phi_np, dims=['lat', 'lon'])
-test_scale_np = np.sin(phi_np)
-test_scale_xr = xr.DataArray(test_scale_np, dims=['lat', 'lon'])
+class Test_Spherical(unittest.TestCase):
 
-test_data = np.zeros(theta_np.shape)
-test_results = []
-test_harmonics = []
-for n in range(max_harm + 1):
-    for m in range(n + 1):
-        test_harmonics.append([m, n])
-        test_results.append(0)
-        if n in [0, 2, 3, 5, 7, 11, 13, 17, 19, 23
-                ] and m in [0, 2, 3, 5, 7, 11, 13, 17, 19, 23]:
-            if m in [2, 5, 11, 17, 23]:
-                test_data += ss.sph_harm(m, n, theta_np, phi_np).imag
-                test_results[-1] = 1j
-            else:
-                test_data += ss.sph_harm(m, n, theta_np, phi_np).real
-                test_results[-1] = 1
+    @classmethod
+    def setUpClass(cls):
+        max_harm = 23
+        num_phi = 360
+        num_theta = 720
 
-test_harmonics_np = np.array(test_harmonics)
-test_harmonics_xr = xr.DataArray(test_harmonics_np, dims=['har',
-                                                          'm,n']).compute()
-test_data_np = test_data
-test_data_xr = xr.DataArray(test_data_np, dims=['lat', 'lon']).compute()
-test_results_np = np.array(test_results)
-test_results_xr = xr.DataArray(test_results_np, dims=['har']).compute()
+        theta = np.linspace(0, ma.tau - ma.tau / num_theta, num_theta)
+        phi = np.linspace(ma.pi / (2 * num_phi), ma.pi - ma.pi / (2 * num_phi),
+                          num_phi)
+        cls.theta_np, cls.phi_np = np.meshgrid(theta, phi)
+        cls.theta_xr = xr.DataArray(cls.theta_np, dims=['lat', 'lon'])
+        cls.phi_xr = xr.DataArray(cls.phi_np, dims=['lat', 'lon'])
+        cls.test_scale_np = np.sin(phi_np)
+        cls.test_scale_xr = xr.DataArray(cls.test_scale_np,
+                                         dims=['lat', 'lon']).compute()
 
+        test_data = np.zeros(cls.theta_np.shape)
+        test_results = []
+        test_harmonics = []
+        for n in range(max_harm + 1):
+            for m in range(n + 1):
+                test_harmonics.append([m, n])
+                test_results.append(0)
+                if n in [0, 2, 3, 5, 7, 11, 13, 17, 19, 23
+                        ] and m in [0, 2, 3, 5, 7, 11, 13, 17, 19, 23]:
+                    if m in [2, 5, 11, 17, 23]:
+                        test_data += ss.sph_harm(m, n, theta_np, phi_np).imag
+                        test_results[-1] = 1j
+                    else:
+                        test_data += ss.sph_harm(m, n, theta_np, phi_np).real
+                        test_results[-1] = 1
 
-def test_decomposition_np():
-    results_np = decomposition(test_data_np, test_scale_np, theta_np, phi_np)
-    np.testing.assert_almost_equal(results_np, test_results_np, decimal=3)
+        cls.test_harmonics_np = np.array(test_harmonics)
+        cls.test_harmonics_xr = xr.DataArray(
+            cls.test_harmonics_np,
+            dims=['har', 'm,n'],
+        ).compute()
+        cls.test_data_np = test_data
+        cls.test_data_xr = xr.DataArray(
+            cls.test_data_np,
+            dims=['lat', 'lon'],
+        ).compute()
+        cls.test_results_np = np.array(test_results)
+        cls.test_results_xr = xr.DataArray(
+            cls.test_results_np,
+            dims=['har'],
+        ).compute()
 
+    def test_decomposition_np(self):
+        results_np = decomposition(self.test_data_np, self.test_scale_np,
+                                   self.theta_np, self.phi_np)
+        np.testing.assert_almost_equal(results_np,
+                                       self.test_results_np,
+                                       decimal=3)
 
-def test_decomposition_xr():
-    results_xr = decomposition(test_data_xr, test_scale_xr, theta_xr, phi_xr)
-    np.testing.assert_almost_equal(results_xr.to_numpy(),
-                                   test_results_xr.to_numpy(),
-                                   decimal=3)
+    def test_decomposition_xr(self):
+        results_xr = decomposition(self.test_data_xr, self.test_scale_xr,
+                                   self.theta_xr, self.phi_xr)
+        np.testing.assert_almost_equal(results_xr.to_numpy(),
+                                       self.test_results_xr.to_numpy(),
+                                       decimal=3)
 
+    def test_recomposition_np(self):
+        data_np = recomposition(self.test_results_np, self.theta_np,
+                                self.phi_np)
+        np.testing.assert_almost_equal(data_np, self.test_data_np)
 
-def test_recomposition_np():
-    data_np = recomposition(test_results_np, theta_np, phi_np)
-    np.testing.assert_almost_equal(data_np, test_data_np)
+    def test_recomposition_xr(self):
+        data_xr = recomposition(self.test_results_xr, self.theta_xr,
+                                self.phi_xr)
+        np.testing.assert_almost_equal(data_xr.to_numpy(),
+                                       self.test_data_xr.to_numpy())
 
+    def test_scale_voronoi_np(self):
+        scale_np = scale_voronoi(self.theta_np, self.phi_np)
+        np.testing.assert_almost_equal(
+            scale_np / np.sum(scale_np, axis=(0, 1)),
+            self.test_scale_np / np.sum(self.test_scale_np, axis=(0, 1)))
 
-def test_recomposition_xr():
-    data_xr = recomposition(test_results_xr, theta_xr, phi_xr)
-    np.testing.assert_almost_equal(data_xr.to_numpy(), test_data_xr.to_numpy())
-
-
-def test_scale_voronoi_np():
-    scale_np = scale_voronoi(theta_np, phi_np)
-    np.testing.assert_almost_equal(
-        scale_np / np.sum(scale_np, axis=(0, 1)),
-        test_scale_np / np.sum(test_scale_np, axis=(0, 1)))
-
-
-def test_scale_voronoi_xr():
-    scale_xr = scale_voronoi(theta_xr, phi_xr)
-    np.testing.assert_almost_equal(
-        scale_xr / np.sum(scale_xr, axis=(0, 1)),
-        test_scale_xr / np.sum(test_scale_xr, axis=(0, 1)))
+    def test_scale_voronoi_xr(self):
+        scale_xr = scale_voronoi(self.theta_xr, self.phi_xr)
+        np.testing.assert_almost_equal(
+            scale_xr / np.sum(scale_xr, axis=(0, 1)),
+            self.test_scale_xr / np.sum(self.test_scale_xr, axis=(0, 1)))

--- a/test/test_spherical.py
+++ b/test/test_spherical.py
@@ -8,9 +8,9 @@ from typing import Union
 # Import from directory structure if coverage test, or from installed
 # packages otherwise
 if "--cov" in str(sys.argv):
-    from src.geocat.comp import harmonic_decomposition, harmonic_recomposition
+    from src.geocat.comp import decomposition, recomposition, scale_voronoi
 else:
-    from geocat.comp import harmonic_decomposition, harmonic_recomposition
+    from geocat.comp import decomposition, recomposition, scale_voronoi
 
 max_harm = 23
 num_phi = 360

--- a/test/test_spherical.py
+++ b/test/test_spherical.py
@@ -49,10 +49,12 @@ class Test_Spherical(unittest.TestCase):
                 if n in [0, 2, 3, 5, 7, 11, 13, 17, 19, 23
                         ] and m in [0, 2, 3, 5, 7, 11, 13, 17, 19, 23]:
                     if m in [2, 5, 11, 17, 23]:
-                        test_data += ss.sph_harm(m, n, theta_np, phi_np).imag
+                        test_data += ss.sph_harm(m, n, cls.theta_np,
+                                                 cls.phi_np).imag
                         test_results[-1] = 1j
                     else:
-                        test_data += ss.sph_harm(m, n, theta_np, phi_np).real
+                        test_data += ss.sph_harm(m, n, cls.theta_np,
+                                                 cls.phi_np).real
                         test_results[-1] = 1
 
         cls.test_harmonics_np = np.array(test_harmonics)

--- a/test/test_spherical.py
+++ b/test/test_spherical.py
@@ -64,22 +64,20 @@ test_results_xr = xr.DataArray(test_results_np,
 def test_decomposition_np():
     results_np = harmonic_decomposition(test_data_np, scale_phi_np, theta_np,
                                         phi_np)
-    np.testing.assert_almost_equal(results_np, test_results_np, decimal=3)
+    np.testing.assert_almost_equal(results_np, test_results_np)
 
 
 def test_decomposition_xr():
     results_xr = harmonic_decomposition(test_data_xr, scale_phi_xr, theta_xr,
                                         phi_xr)
-    np.testing.assert_almost_equal(results_xr.data,
-                                   test_results_xr.data,
-                                   decimal=3)
+    np.testing.assert_almost_equal(results_xr.data, test_results_xr.data)
 
 
 def test_recomposition_np():
     data_np = harmonic_recomposition(test_results_np, theta_np, phi_np)
-    np.testing.assert_almost_equal(data_np, test_data_np, decimal=3)
+    np.testing.assert_almost_equal(data_np, test_data_np)
 
 
 def test_recomposition_xr():
     data_xr = harmonic_recomposition(test_results_xr, theta_xr, phi_xr)
-    np.testing.assert_almost_equal(data_xr.data, test_data_xr.data, decimal=3)
+    np.testing.assert_almost_equal(data_xr.data, test_data_xr.data)

--- a/test/test_spherical.py
+++ b/test/test_spherical.py
@@ -21,11 +21,10 @@ num_theta = 720
 theta = np.linspace(0, ma.tau - ma.tau / num_theta, num_theta)
 phi = np.linspace(ma.pi / (2 * num_phi), ma.pi - ma.pi / (2 * num_phi), num_phi)
 theta_np, phi_np = np.meshgrid(theta, phi)
-theta_xr = xr.DataArray(theta_np, dims=['lat', 'lon']).chunk(data_chunkshape)
-phi_xr = xr.DataArray(phi_np, dims=['lat', 'lon']).chunk(data_chunkshape)
+theta_xr = xr.DataArray(theta_np, dims=['lat', 'lon'])
+phi_xr = xr.DataArray(phi_np, dims=['lat', 'lon'])
 scale_phi_np = np.sin(phi_np)
-scale_phi_xr = xr.DataArray(scale_phi_np, dims=['lat',
-                                                'lon']).chunk(data_chunkshape)
+scale_phi_xr = xr.DataArray(scale_phi_np, dims=['lat', 'lon'])
 
 test_data = np.zeros(theta_np.shape)
 test_results = []


### PR DESCRIPTION
Addresses #206

Replaces `xr.ufuncs` with `np.ufuncs` in `meteorology.py`