### PR TITLE
Fix CI failures by pinning dask

### DIFF
--- a/build_envs/upstream-dev-environment.yml
+++ b/build_envs/upstream-dev-environment.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   - python
   - cftime
-  - dask
+  - dask=2022.05.0
   - distributed
   - eofs
   - geocat-datafiles  # for tests


### PR DESCRIPTION
Summary of changes:
- pins dask to 2022.05.0

Note: I want to try to figure out what's happening to submit a bug report to dask, but I am unable to replicate this locally at this time. When/if that happens, I'll link that here and make another PR to unpin when a fix is made.