### PR TITLE
Update citation texts per Zenodo DOI implementation per-version

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,7 +1,7 @@
 cff-version: 1.2.0
 message: "If you use this software, please cite it as below."
 authors:
-  - given-names: Visualization & Analysis Systems Technologies
-title: Geoscience Community Analysis Toolkit: GeoCAT-comp
+  - given-names: "Visualization & Analysis Systems Technologies"
+title: "Geoscience Community Analysis Toolkit: GeoCAT-comp"
 doi: 10.5281/zenodo.6607205
 url: "https://github.com/NCAR/geocat-comp"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,7 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+authors:
+  - given-names: Visualization & Analysis Systems Technologies
+title: Geoscience Community Analysis Toolkit: GeoCAT-comp
+doi: 10.5281/zenodo.6607205
+url: "https://github.com/NCAR/geocat-comp"

--- a/README.md
+++ b/README.md
@@ -64,23 +64,6 @@ intended primarily for internal use.
 If you use this software, please cite it as described at the [GeoCAT-comp - Citation](
 https://geocat-comp.readthedocs.io/en/latest/citation.html) page.
 
-Cite GeoCAT-comp using the following text:
-
-<> Visualization & Analysis Systems Technologies. (Year).
-Geoscience Community Analysis Toolkit (GeoCAT): GeoCAT-comp version \<version\>) [Software].
-Boulder, CO: UCAR/NCAR - Computational and Informational System Lab. doi:10.5065/A8PP-4358.
-
-Update the GeoCAT-comp version and year as appropriate. For example:
-
-<> Visualization & Analysis Systems Technologies. (2021).
-Geoscience Community Analysis Toolkit (GeoCAT-comp version 2021.04.0) [Software].
-Boulder, CO: UCAR/NCAR - Computational and Informational System Lab. doi:10.5065/A8PP-4358.
-
-For further information, please refer to
-[GeoCAT homepage - Citation](https://geocat.ucar.edu/pages/citation.html).
-
-
-
 
 
 [github-ci-badge]: https://img.shields.io/github/workflow/status/NCAR/geocat-comp/CI?label=CI&logo=github&style=for-the-badge

--- a/README.md
+++ b/README.md
@@ -61,10 +61,13 @@ intended primarily for internal use.
 
 # Citing GeoCAT-comp
 
+If you use this software, please cite it as described at the [GeoCAT-comp - Citation](
+https://geocat-comp.readthedocs.io/en/latest/citation.html) page.
+
 Cite GeoCAT-comp using the following text:
 
 <> Visualization & Analysis Systems Technologies. (Year).
-Geoscience Community Analysis Toolkit (GeoCAT-comp version \<version\>) [Software].
+Geoscience Community Analysis Toolkit (GeoCAT): GeoCAT-comp version \<version\>) [Software].
 Boulder, CO: UCAR/NCAR - Computational and Informational System Lab. doi:10.5065/A8PP-4358.
 
 Update the GeoCAT-comp version and year as appropriate. For example:
@@ -93,6 +96,8 @@ For further information, please refer to
 [conda-badge]: https://img.shields.io/conda/vn/ncar/geocat-comp?logo=anaconda&style=for-the-badge
 [conda-link]: https://anaconda.org/ncar/geocat-comp
 [license-badge]: https://img.shields.io/github/license/NCAR/geocat-comp?style=for-the-badge
-[doi-badge]: https://img.shields.io/badge/DOI-10.5065%2Fa8pp--4358-brightgreen?style=for-the-badge
-[doi-link]: https://doi.org/10.5065/a8pp-4358
+[comment]: <> ([doi-badge]: https://img.shields.io/badge/DOI-10.5065%2Fa8pp--4358-brightgreen?style=for-the-badge)
+[comment]: <> ([doi-link]: https://doi.org/10.5065/a8pp-4358)
+[doi-badge]: https://zenodo.org/badge/DOI/10.5281/zenodo.6607205.svg
+[doi-link]: https://doi.org/10.5281/zenodo.6607205
 [repo-link]: https://github.com/NCAR/geocat-comp

--- a/docs/citation.rst
+++ b/docs/citation.rst
@@ -35,8 +35,8 @@ Please find DOIs for all the GeoCAT-comp versions `here
 <https://zenodo.org/search?page=1&size=20&q=conceptrecid:%226607205%22&sort=-version&all_versions=True>`_.
 
 Please note: The DOI minting service, Zenodo, might be suggesting their own citation text (as
-they are the publisher of such DOIs). We prefer the text we recommend here to be used; however, either
-way is acceptable.
+they are the publisher of such DOIs) in their website. We prefer the text we recommend here to be used;
+however, either way is acceptable.
 
 For further information, please refer to
 `GeoCAT homepage - Citation <https://geocat.ucar.edu/pages/citation.html>`_.

--- a/docs/citation.rst
+++ b/docs/citation.rst
@@ -4,17 +4,39 @@ Citation
 How to cite GeoCAT-comp
 -----------------------
 
-Cite GeoCAT-comp using the following text:
+If you use this software, please cite it as described below.
+
+Each GeoCAT-comp version is assigned a separate Digital Object Identifier (DOI) to allow
+users to access older releases. This ensures that users are not only able to cite the specific
+software version through DOIs but are also able to download & use the corresponding release for
+reproducibility purposes.
+
+If you would like to cite GeoCAT-comp as a whole (without referring to a specific version), use
+the following text:
 
 **Visualization & Analysis Systems Technologies. (Year).
-Geoscience Community Analysis Toolkit (GeoCAT-comp version \<version\>) [Software].
-Boulder, CO: UCAR/NCAR - Computational and Informational System Lab. doi:10.5065/A8PP-4358.**
+Geoscience Community Analysis Toolkit: GeoCAT-comp [Software].
+Boulder, CO: UCAR/NCAR - Computational and Informational System Lab. doi:10.5281/zenodo.6607205.**
 
-Update the GeoCAT-comp version and year as appropriate. For example:
+Instead, if you would like to cite a specific version of GeoCAT-comp, use the following text:
 
-**Visualization & Analysis Systems Technologies. (2021).
-Geoscience Community Analysis Toolkit (GeoCAT-comp version 2021.04.0) [Software].
-Boulder, CO: UCAR/NCAR - Computational and Informational System Lab. doi:10.5065/A8PP-4358.**
+**Visualization & Analysis Systems Technologies. (Year).
+Geoscience Community Analysis Toolkit: GeoCAT-comp (v\<version\>) [Software].
+Boulder, CO, USA: UCAR/NCAR - Computational and Informational System Lab. doi:\<DOI\>.**
+
+In the above citation text, update the year, GeoCAT-comp version, and DOI as appropriate. For
+example:
+
+**Visualization & Analysis Systems Technologies. (2022).
+Geoscience Community Analysis Toolkit: GeoCAT-comp (v2022.04.0) [Software].
+Boulder, CO, USA: UCAR/NCAR - Computational and Informational System Lab. doi:10.5281/zenodo.6607349.**
+
+Please find DOIs for all the GeoCAT-comp versions `here
+<https://zenodo.org/search?page=1&size=20&q=conceptrecid:%226607205%22&sort=-version&all_versions=True>`_.
+
+Please note: The DOI minting service, Zenodo, might be suggesting their own citation text (as
+they are the publisher of such DOIs). We prefer the text we recommend here to be used; however, either
+way is acceptable.
 
 For further information, please refer to
 `GeoCAT homepage - Citation <https://geocat.ucar.edu/pages/citation.html>`_.


### PR DESCRIPTION
We are starting to generate DOIs for each GeoCAT-comp version via the Zenodo minting service. Texts regarding citation are updated to reflect this change.