### PR TITLE
Make local install for docs better

### DIFF
--- a/build_envs/docs.yml
+++ b/build_envs/docs.yml
@@ -19,3 +19,6 @@ dependencies:
     - sphinx-design
     - nbsphinx
     - xskillscore
+    - pip
+    - pip:
+        - -e ..

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,8 +20,10 @@ from sphinx.application import Sphinx
 from sphinx.util import logging
 from textwrap import dedent, indent
 
-sys.path.insert(0,
-                os.path.abspath('../'))  # Source code dir relative to this file
+sys.path.insert(
+    0, os.path.abspath('../src/'))  # Source code dir relative to this file
+
+print("sys.path:", sys.path)
 
 import geocat.comp
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,9 +20,6 @@ from sphinx.application import Sphinx
 from sphinx.util import logging
 from textwrap import dedent, indent
 
-sys.path.insert(
-    0, os.path.abspath('../src/'))  # Source code dir relative to this file
-
 print("sys.path:", sys.path)
 
 import geocat.comp


### PR DESCRIPTION
Closes #271

Summary of changes:

- uses docs env file to make an editable local install
- adds a print statement to conf.py that prints the sys path at time of documentation generation for debugging purposes
- removes a sys path add that isn't needed with new pip install method