### PR TITLE
Documentation and Link Checker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,10 +62,7 @@ jobs:
           name: codecov-umbrella
           fail_ci_if_error: false
 
-  link-check:
-    runs-on: ubuntu-latest
-    steps:
-      - name: conda_setup
+      - name: Make docs
         uses: conda-incubator/setup-miniconda@v2
         with:
           activate-environment: gc-docs
@@ -73,9 +70,6 @@ jobs:
           python-version: 3.9
           channels: conda-forge
           environment-file: build_envs/docs.yml
-      - name: Link Check
         run: |
-          pwd
-          tree
           cd docs
           make linkcheck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,4 +84,3 @@ jobs:
         run: |
           cd docs
           make linkcheck
-          cat _build/linkcheck/output.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,8 @@ jobs:
   link-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: conda_setup
+        uses: conda-incubator/setup-miniconda@v2
         with:
           activate-environment: gc-docs
           channel-priority: strict

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,21 +9,6 @@ on:
   workflow_dispatch:
 
 jobs:
-  link-check:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          activate-environment: gc-docs
-          channel-priority: strict
-          python-version: 3.9
-          channels: conda-forge
-          environment-file: build_envs/docs.yml
-      - name: Link Check
-        run: |
-          cd docs
-          make linkcheck
-
   test:
     # if: |
     #   github.repository == 'NCAR/geocat-comp'
@@ -76,3 +61,18 @@ jobs:
           env_vars: OS,PYTHON
           name: codecov-umbrella
           fail_ci_if_error: false
+
+  link-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          activate-environment: gc-docs
+          channel-priority: strict
+          python-version: 3.9
+          channels: conda-forge
+          environment-file: build_envs/docs.yml
+      - name: Link Check
+        run: |
+          cd docs
+          make linkcheck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,6 @@ jobs:
           environment-file: build_envs/docs.yml
       - name: Link Check
         run: |
-          conda activate gc-docs
           cd docs
           make linkcheck
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,5 +74,7 @@ jobs:
           environment-file: build_envs/docs.yml
       - name: Link Check
         run: |
+          pwd
+          tree
           cd docs
           make linkcheck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,17 @@ jobs:
           name: codecov-umbrella
           fail_ci_if_error: false
 
-      - name: Make docs
+  link-check:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+        with:
+          token: ${{ github.token }}
+      - name: conda_setup
         uses: conda-incubator/setup-miniconda@v2
         with:
           activate-environment: gc-docs
@@ -70,6 +80,9 @@ jobs:
           python-version: 3.9
           channels: conda-forge
           environment-file: build_envs/docs.yml
+      - name: Link Check
         run: |
+          pwd
+          tree
           cd docs
           make linkcheck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,22 @@ on:
   workflow_dispatch:
 
 jobs:
+  link-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          activate-environment: gc-docs
+          channel-priority: strict
+          python-version: 3.9
+          channels: conda-forge
+          environment-file: build_envs/docs.yml
+      - name: Link Check
+        run: |
+          conda activate gc-docs
+          cd docs
+          make linkcheck
+
   test:
     # if: |
     #   github.repository == 'NCAR/geocat-comp'
@@ -38,7 +54,7 @@ jobs:
           activate-environment: geocat_comp_build
           channel-priority: strict
           python-version: ${{ matrix.python-version }}
-          channels: conda-forge, ncar
+          channels: conda-forge
           environment-file: build_envs/environment.yml
 
       - name: Install geocat-comp

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,9 +80,8 @@ jobs:
           python-version: 3.9
           channels: conda-forge
           environment-file: build_envs/docs.yml
-      - name: Link Check
+      - name: Make docs with linkcheck
         run: |
-          pwd
-          tree
           cd docs
           make linkcheck
+          cat _build/linkcheck/output.txt

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -33,6 +33,8 @@ on geosciences data. Many of these functions originated in NCL and were translat
 Python with the help of GeoCAT-comp; however, developers are welcome to come up with
 novel computational functions for geosciences data.
 
+This is a `broken link <http://www.brokenlinkplease.com/>`__
+
 .. grid:: 1 1 2 2
     :gutter: 2
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -33,8 +33,6 @@ on geosciences data. Many of these functions originated in NCL and were translat
 Python with the help of GeoCAT-comp; however, developers are welcome to come up with
 novel computational functions for geosciences data.
 
-This is a `broken link <http://www.brokenlinkplease.com/>`__
-
 .. grid:: 1 1 2 2
     :gutter: 2
 


### PR DESCRIPTION
Closes #264

Summary of changes:
- removes ncar conda channel from ci environment sources
- adds a job to the ci that uses sphinx's `make linkcheck` to:
    - check documentation generation
    - check for any broken links