### PR TITLE
Pin pint

### DIFF
--- a/build_envs/environment.yml
+++ b/build_envs/environment.yml
@@ -1,7 +1,6 @@
 name: geocat_comp_build
 channels:
   - conda-forge
-  - ncar
 dependencies:
   - python
   - cf_xarray>=0.3.1
@@ -14,6 +13,7 @@ dependencies:
   - metpy
   - netcdf4  # for tests
   - numpy
+  - pint<0.20
   - pre-commit
   - pytest  # for tests
   - pytest-cov  # for tests

--- a/build_envs/upstream-dev-environment.yml
+++ b/build_envs/upstream-dev-environment.yml
@@ -1,7 +1,6 @@
 name: geocat_comp_build
 channels:
   - conda-forge
-  - ncar
 dependencies:
   - python
   - cftime
@@ -13,6 +12,7 @@ dependencies:
   - metpy
   - netcdf4  # for tests
   - numpy
+  - pint<0.20
   - pytest  # for tests
   - pytest-cov  # for tests
   - pip


### PR DESCRIPTION
Temporary solution to #277 

Summary of changes:
- pins pint to <0.20 in `environment.yml` and `upstream-dev-environment.yml`
- removes ncar channel from above files, as is no longer relevant