### PR TITLE
Expand upstream CI

### DIFF
--- a/.github/workflows/upstream-dev-ci.yml
+++ b/.github/workflows/upstream-dev-ci.yml
@@ -30,7 +30,7 @@ jobs:
           channel-priority: strict
           mamba-version: '*'
           python-version: 3.8
-          channels: conda-forge, ncar
+          channels: conda-forge
           environment-file: build_envs/upstream-dev-environment.yml
 
       - name: Install geocat-comp

--- a/build_envs/upstream-dev-environment.yml
+++ b/build_envs/upstream-dev-environment.yml
@@ -4,19 +4,19 @@ channels:
 dependencies:
   - python>=3.8, <3.11
   - cftime
-  - dask
-  - distributed
   - eofs
   - geocat-datafiles  # for tests
   - geocat-f2py
-  - metpy
   - netcdf4  # for tests
-  - numpy
-  - pint<0.20
   - pytest  # for tests
   - pytest-cov  # for tests
   - pip
-  - xskillscore
   - pip:
+    - git+https://github.com/Unidata/MetPy.git
+    - git+https://github.com/numpy/numpy.git
+    - git+https://github.com/dask/dask.git
+    - git+https://github.com/dask/distributed.git
+    - git+https://github.com/hgrecco/pint.git
     - git+https://github.com/pydata/xarray.git
     - git+https://github.com/xarray-contrib/cf-xarray.git
+    - git+https://github.com/xarray-contrib/xskillscore.git


### PR DESCRIPTION
Closes #289 

Summary of changes:
- removes ncar channel from upstream environment file
- moves more packages to install from github through pip instead of conda releases