### PR TITLE
Add check to avoid calculating monthly averages on monthly data

### DIFF
--- a/src/geocat/comp/climatologies.py
+++ b/src/geocat/comp/climatologies.py
@@ -607,8 +607,9 @@ def climatology_average(
     calendar = _infer_calendar_name(dset[time_dim])
 
     if freq == 'season':
-        # Calculate monthly average before calculating seasonal climatologies
-        dset = dset.resample({time_dim: frequency}).mean().dropna(time_dim)
+        if xr.infer_freq(dset[time_dim]) != 'MS':
+            # Calculate monthly average before calculating seasonal climatologies
+            dset = dset.resample({time_dim: frequency}).mean().dropna(time_dim)
 
         # Compute the weights for the months in each season so that the
         # seasonal averages account for months being of different lengths


### PR DESCRIPTION
This PR fixes a bug found in `climatology_average`. When monthly data is passed into the function to compute seasonal averages, the program attempts to compute monthly averages from monthly data which throws an error. A small check has been added to make sure the data isn't monthly before computing the monthly averages and then seasonal averages.