### PR TITLE
CI failures quick patch

### DIFF
--- a/src/geocat/comp/climatologies.py
+++ b/src/geocat/comp/climatologies.py
@@ -4,8 +4,6 @@ import numpy as np
 import typing
 import xarray as xr
 
-xr.set_options(keep_attrs=True)
-
 _FREQUENCIES = {"day", "month", "year", "season"}
 
 

--- a/src/geocat/comp/climatologies.py
+++ b/src/geocat/comp/climatologies.py
@@ -4,6 +4,8 @@ import numpy as np
 import typing
 import xarray as xr
 
+xr.set_options(keep_attrs=True)
+
 _FREQUENCIES = {"day", "month", "year", "season"}
 
 


### PR DESCRIPTION
Resolves #308 
Related: https://github.com/pydata/xarray/issues/7362

This PR removes `xr.set_options(keep_attrs=True)` from `climatology.py`. This was causing the bug described in the xarray issue above. This change will clear up the CI failures and will need to be followed by another RP that incorporates an optional argument of `keep_attrs=True` for the climatology functions affected by the change.