### PR TITLE
Add `keep_attrs` to functions

### DIFF
--- a/src/geocat/comp/climatologies.py
+++ b/src/geocat/comp/climatologies.py
@@ -229,7 +229,10 @@ def climatology(
     # TODO: Compute weighted climatologies when `time_bounds` are available
     clim = grouped.mean(time_coord_name, keep_attrs=keep_attrs)
     if time_invariant_vars:
-        return xr.concat([dset[time_invariant_vars], clim], dim=time_coord_name)
+        if keep_attrs == False:
+            return xr.concat([dset[time_invariant_vars], clim], combine_attrs='drop', dim=time_coord_name)
+        else:
+            return xr.concat([dset[time_invariant_vars], clim], dim=time_coord_name)
     else:
         return clim
 

--- a/src/geocat/comp/climatologies.py
+++ b/src/geocat/comp/climatologies.py
@@ -230,9 +230,12 @@ def climatology(
     clim = grouped.mean(time_coord_name, keep_attrs=keep_attrs)
     if time_invariant_vars:
         if keep_attrs == False:
-            return xr.concat([dset[time_invariant_vars], clim], combine_attrs='drop', dim=time_coord_name)
+            return xr.concat([dset[time_invariant_vars], clim],
+                             combine_attrs='drop',
+                             dim=time_coord_name)
         else:
-            return xr.concat([dset[time_invariant_vars], clim], dim=time_coord_name)
+            return xr.concat([dset[time_invariant_vars], clim],
+                             dim=time_coord_name)
     else:
         return clim
 
@@ -537,16 +540,13 @@ def calendar_average(
         # seasonal/yearly averages account for months being of different lengths
         month_length = dset[time_dim].dt.days_in_month.resample(
             {time_dim: frequency})
-        weights = month_length.map(
-            lambda group: group / group.sum())
+        weights = month_length.map(lambda group: group / group.sum())
 
         dset_weighted = dset * weights
-        dset = (dset_weighted).resample({
-            time_dim: frequency
-        }).sum()
+        dset = (dset_weighted).resample({time_dim: frequency}).sum()
 
     # Center the time coordinate by inferring and then averaging the time bounds
-    dset= _calculate_center_of_time_bounds(dset,
+    dset = _calculate_center_of_time_bounds(dset,
                                             time_dim,
                                             frequency,
                                             calendar,

--- a/src/geocat/comp/climatologies.py
+++ b/src/geocat/comp/climatologies.py
@@ -66,7 +66,7 @@ def _calculate_center_of_time_bounds(
         calendar: str,
         start: typing.Union[str, cftime.datetime],
         end: typing.Union[str, cftime.datetime],
-        keep_attrs: bool = False) -> typing.Union[xr.Dataset, xr.DataArray]:
+        keep_attrs: bool = None) -> typing.Union[xr.Dataset, xr.DataArray]:
     """Helper function to determine the time bounds based on the given dataset
     and frequency and then calculate the averages of them.
 
@@ -96,7 +96,8 @@ def _calculate_center_of_time_bounds(
 
     keep_attrs : bool, optional
         If True, attrs will be copied from the original object to the new one.
-        If False, the new object will be returned without attributes. Defaults to False.
+        If False, the new object will be returned without attributes.
+        Defaults to None which means the attrs will only be kept in unambiguous circumstances.
 
     Returns
     -------
@@ -134,7 +135,7 @@ def climatology(
         dset: typing.Union[xr.DataArray, xr.Dataset],
         freq: str,
         time_coord_name: str = None,
-        keep_attrs: bool = False) -> typing.Union[xr.DataArray, xr.Dataset]:
+        keep_attrs: bool = None) -> typing.Union[xr.DataArray, xr.Dataset]:
     """Compute climatologies for a specified time frequency.
 
     Parameters
@@ -156,7 +157,8 @@ def climatology(
 
     keep_attrs : bool, optional
         If True, attrs will be copied from the original object to the new one.
-        If False, the new object will be returned without attributes. Defaults to False.
+        If False, the new object will be returned without attributes.
+        Defaults to None which means the attrs will only be kept in unambiguous circumstances.
 
     Returns
     -------
@@ -327,7 +329,7 @@ def month_to_season(
         dset: typing.Union[xr.Dataset, xr.DataArray],
         season: str,
         time_coord_name: str = None,
-        keep_attrs: bool = False) -> typing.Union[xr.Dataset, xr.DataArray]:
+        keep_attrs: bool = None) -> typing.Union[xr.Dataset, xr.DataArray]:
     """Computes a user-specified three-month seasonal mean.
 
     This function takes an xarray dataset containing monthly data spanning years and
@@ -359,7 +361,8 @@ def month_to_season(
 
     keep_attrs : bool, optional
         If True, attrs will be copied from the original object to the new one.
-        If False, the new object will be returned without attributes. Defaults to False.
+        If False, the new object will be returned without attributes.
+        Defaults to None which means the attrs will only be kept in unambiguous circumstances.
 
     Returns
     -------
@@ -432,7 +435,7 @@ def calendar_average(
         dset: typing.Union[xr.DataArray, xr.Dataset],
         freq: str,
         time_dim: str = None,
-        keep_attrs: bool = False) -> typing.Union[xr.DataArray, xr.Dataset]:
+        keep_attrs: bool = None) -> typing.Union[xr.DataArray, xr.Dataset]:
     """This function divides the data into time periods (months, seasons, etc)
     and computes the average for the data in each one.
 
@@ -462,7 +465,8 @@ def calendar_average(
 
     keep_attrs : bool, optional
         If True, attrs will be copied from the original object to the new one.
-        If False, the new object will be returned without attributes. Defaults to False.
+        If False, the new object will be returned without attributes.
+        Defaults to None which means the attrs will only be kept in unambiguous circumstances.
 
     Examples
     --------
@@ -546,7 +550,7 @@ def climatology_average(
         dset: typing.Union[xr.DataArray, xr.Dataset],
         freq: str,
         time_dim: str = None,
-        keep_attrs: bool = False) -> typing.Union[xr.DataArray, xr.Dataset]:
+        keep_attrs: bool = None) -> typing.Union[xr.DataArray, xr.Dataset]:
     """This function calculates long term hourly, daily, monthly, or seasonal
     averages across all years in the given dataset.
 
@@ -570,7 +574,8 @@ def climatology_average(
 
     keep_attrs : bool, optional
         If True, attrs will be copied from the original object to the new one.
-        If False, the new object will be returned without attributes. Defaults to False.
+        If False, the new object will be returned without attributes.
+        Defaults to None which means the attrs will only be kept in unambiguous circumstances.
 
     Returns
     -------

--- a/src/geocat/comp/climatologies.py
+++ b/src/geocat/comp/climatologies.py
@@ -651,6 +651,9 @@ def climatology_average(
     calendar = _infer_calendar_name(dset[time_dim])
 
     if freq == 'season':
+        attrs = {}
+        if keep_attrs or keep_attrs is None:
+            attrs = dset.attrs
         if xr.infer_freq(dset[time_dim]) != 'MS':
             # Calculate monthly average before calculating seasonal climatologies
             dset = dset.resample({
@@ -664,6 +667,7 @@ def climatology_average(
         weights = month_length / month_length.sum(keep_attrs=keep_attrs)
         dset = (dset * weights).groupby(f"{time_dim}.season")
         dset = dset.sum(dim=time_dim, keep_attrs=keep_attrs)
+        return dset.assign_attrs(attrs)
     else:
         # Retrieve floor of median year
         median_yr = np.median(dset[time_dim].dt.year.values)
@@ -681,6 +685,7 @@ def climatology_average(
             frequency,
             calendar,
             start=f'{median_yr:.0f}-{start_time}',
-            end=f'{median_yr:.0f}-{end_time}')
+            end=f'{median_yr:.0f}-{end_time}',
+            keep_attrs=keep_attrs)
 
-    return dset
+        return dset

--- a/test/test_climatologies.py
+++ b/test/test_climatologies.py
@@ -362,6 +362,18 @@ def test_daily_monthly_to_yearly_calendar_average(dset, expected):
 
 
 # Computational Tests for climatology_average()
+@pytest.mark.parametrize('dset, freq', [(minute, 'hour'),
+                                        (hourly, 'day'),
+                                        (daily, 'month'),
+                                        (monthly, 'season')])
+@pytest.mark.parametrize('keep_attrs', [None, True, False])
+def test_climatology_average_keep_attrs(dset, freq, keep_attrs):
+    result = climatology_average(dset, freq, keep_attrs=keep_attrs)
+    if keep_attrs or keep_attrs == None:
+        assert result.attrs == dset.attrs
+    elif not keep_attrs:
+        assert result.attrs == {}
+
 hour_clim = np.concatenate([np.arange(8784.5, 11616.5, 2),
                             np.arange(2832.5, 2880.5, 2),
                             np.arange(11640.5, 26328.5, 2)])\

--- a/test/test_climatologies.py
+++ b/test/test_climatologies.py
@@ -225,6 +225,19 @@ daily = _get_dummy_data('2020-01-01', '2021-12-31', 'D', 1, 1)
 monthly = _get_dummy_data('2020-01-01', '2021-12-01', 'MS', 1, 1)
 
 # Computational Tests for calendar_average()
+@pytest.mark.parametrize('dset, freq', [(minute, 'hour'),
+                                        (hourly, 'day'),
+                                        (daily, 'month'),
+                                        (monthly, 'season'),
+                                        (monthly, 'year')])
+@pytest.mark.parametrize('keep_attrs', [None, True, False])
+def test_calendar_average_keep_attrs(dset, freq, keep_attrs):
+    result = calendar_average(dset, freq, keep_attrs=keep_attrs)
+    if keep_attrs or keep_attrs == None:
+        assert result.attrs == dset.attrs
+    elif not keep_attrs:
+        assert result.attrs == {}
+
 hour_avg = np.arange(0.5, 35088.5, 2).reshape((365 + 366) * 24, 1, 1)
 hour_avg_time = xr.cftime_range('2020-01-01 00:30:00',
                                 '2021-12-31 23:30:00',

--- a/test/test_climatologies.py
+++ b/test/test_climatologies.py
@@ -225,9 +225,7 @@ daily = _get_dummy_data('2020-01-01', '2021-12-31', 'D', 1, 1)
 monthly = _get_dummy_data('2020-01-01', '2021-12-01', 'MS', 1, 1)
 
 # Computational Tests for calendar_average()
-@pytest.mark.parametrize('dset, freq', [(minute, 'hour'),
-                                        (hourly, 'day'),
-                                        (daily, 'month'),
+@pytest.mark.parametrize('dset, freq', [(daily, 'month'),
                                         (monthly, 'season'),
                                         (monthly, 'year')])
 @pytest.mark.parametrize('keep_attrs', [None, True, False])
@@ -362,9 +360,7 @@ def test_daily_monthly_to_yearly_calendar_average(dset, expected):
 
 
 # Computational Tests for climatology_average()
-@pytest.mark.parametrize('dset, freq', [(minute, 'hour'),
-                                        (hourly, 'day'),
-                                        (daily, 'month'),
+@pytest.mark.parametrize('dset, freq', [(daily, 'month'),
                                         (monthly, 'season')])
 @pytest.mark.parametrize('keep_attrs', [None, True, False])
 def test_climatology_average_keep_attrs(dset, freq, keep_attrs):

--- a/test/test_climatologies.py
+++ b/test/test_climatologies.py
@@ -37,17 +37,15 @@ def get_fake_dataset(start_month, nmonths, nlats, nlons):
                                   axis=(1, 2))
     var_values = np.tile(month_values, (1, nlats, nlons))
 
-    ds = xr.Dataset(
-        data_vars={
-            "my_var": (("time", "lat", "lon"), var_values.astype("float32")),
-        },
-        coords={
-            "time": months,
-            "lat": lats,
-            "lon": lons
-        },
-        attrs={'Description': 'This is dummy data for testing.'}
-    )
+    ds = xr.Dataset(data_vars={
+        "my_var": (("time", "lat", "lon"), var_values.astype("float32")),
+    },
+                    coords={
+                        "time": months,
+                        "lat": lats,
+                        "lon": lons
+                    },
+                    attrs={'Description': 'This is dummy data for testing.'})
     return ds
 
 
@@ -81,12 +79,13 @@ def _get_dummy_data(start_date,
                     attrs={'Description': 'This is dummy data for testing.'})
     return ds
 
+
 @pytest.mark.parametrize("dataset", [dset_a, dset_b, dset_c["Tair"]])
 @pytest.mark.parametrize("freq", ["day", "month", "year", "season"])
 @pytest.mark.parametrize("keep_attrs", [None, True, False])
 def test_climatology_keep_attrs(dataset, freq, keep_attrs):
     computed_dset = climatology(dataset, freq, keep_attrs=keep_attrs)
-    if keep_attrs or keep_attrs==None:
+    if keep_attrs or keep_attrs == None:
         assert computed_dset.attrs == dataset.attrs
     elif not keep_attrs:
         assert computed_dset.attrs == {}
@@ -145,6 +144,7 @@ complex_dataset = get_fake_dataset(start_month="2001-01",
                                    nlats=10,
                                    nlons=10)
 
+
 @pytest.mark.parametrize("keep_attrs", [None, True, False])
 def test_month_to_season_keep_attrs(keep_attrs):
     season_ds = month_to_season(ds1, 'JFM', keep_attrs=keep_attrs)
@@ -152,6 +152,7 @@ def test_month_to_season_keep_attrs(keep_attrs):
         assert season_ds.attrs == ds1.attrs
     elif not keep_attrs:
         assert season_ds.attrs == {}
+
 
 @pytest.mark.parametrize("dataset, season, expected", [(ds1, "JFM", 2.0),
                                                        (ds1, "JJA", 7.0)])
@@ -224,9 +225,9 @@ daily = _get_dummy_data('2020-01-01', '2021-12-31', 'D', 1, 1)
 
 monthly = _get_dummy_data('2020-01-01', '2021-12-01', 'MS', 1, 1)
 
+
 # Computational Tests for calendar_average()
-@pytest.mark.parametrize('dset, freq', [(daily, 'month'),
-                                        (monthly, 'season'),
+@pytest.mark.parametrize('dset, freq', [(daily, 'month'), (monthly, 'season'),
                                         (monthly, 'year')])
 @pytest.mark.parametrize('keep_attrs', [None, True, False])
 def test_calendar_average_keep_attrs(dset, freq, keep_attrs):
@@ -235,6 +236,7 @@ def test_calendar_average_keep_attrs(dset, freq, keep_attrs):
         assert result.attrs == dset.attrs
     elif not keep_attrs:
         assert result.attrs == {}
+
 
 hour_avg = np.arange(0.5, 35088.5, 2).reshape((365 + 366) * 24, 1, 1)
 hour_avg_time = xr.cftime_range('2020-01-01 00:30:00',
@@ -360,8 +362,7 @@ def test_daily_monthly_to_yearly_calendar_average(dset, expected):
 
 
 # Computational Tests for climatology_average()
-@pytest.mark.parametrize('dset, freq', [(daily, 'month'),
-                                        (monthly, 'season')])
+@pytest.mark.parametrize('dset, freq', [(daily, 'month'), (monthly, 'season')])
 @pytest.mark.parametrize('keep_attrs', [None, True, False])
 def test_climatology_average_keep_attrs(dset, freq, keep_attrs):
     result = climatology_average(dset, freq, keep_attrs=keep_attrs)

--- a/test/test_climatologies.py
+++ b/test/test_climatologies.py
@@ -46,6 +46,7 @@ def get_fake_dataset(start_month, nmonths, nlats, nlons):
             "lat": lats,
             "lon": lons
         },
+        attrs={'Description': 'This is dummy data for testing.'}
     )
     return ds
 
@@ -76,8 +77,19 @@ def _get_dummy_data(start_date,
                         'time': time,
                         'lat': lats,
                         'lon': lons
-                    })
+                    },
+                    attrs={'Description': 'This is dummy data for testing.'})
     return ds
+
+@pytest.mark.parametrize("dataset", [dset_a, dset_b, dset_c["Tair"]])
+@pytest.mark.parametrize("freq", ["day", "month", "year", "season"])
+@pytest.mark.parametrize("keep_attrs", [None, True, False])
+def test_climatology_keep_attrs(dataset, freq, keep_attrs):
+    computed_dset = climatology(dataset, freq, keep_attrs=keep_attrs)
+    if keep_attrs or keep_attrs==None:
+        assert computed_dset.attrs == dataset.attrs
+    elif not keep_attrs:
+        assert computed_dset.attrs == {}
 
 
 def test_climatology_invalid_freq():
@@ -133,6 +145,13 @@ complex_dataset = get_fake_dataset(start_month="2001-01",
                                    nlats=10,
                                    nlons=10)
 
+@pytest.mark.parametrize("keep_attrs", [None, True, False])
+def test_month_to_season_keep_attrs(keep_attrs):
+    season_ds = month_to_season(ds1, 'JFM', keep_attrs=keep_attrs)
+    if keep_attrs or keep_attrs == None:
+        assert season_ds.attrs == ds1.attrs
+    elif not keep_attrs:
+        assert season_ds.attrs == {}
 
 @pytest.mark.parametrize("dataset, season, expected", [(ds1, "JFM", 2.0),
                                                        (ds1, "JJA", 7.0)])


### PR DESCRIPTION
Closes #314

I cannot test these functions with `np.ndarray` inputs since they don't yet explicitly support that data structure. As far as I can tell, the aggregation functions for `xarray.core.groupby` and `xarray.core.resample` objects are the only ones used in this file that have `keep_attrs` as an argument.

TODO from our discussion below:
- [x] set the default to None to preserve xarray default behavior
- [x] add a test for the new kwarg