### PR TITLE
Resolve CI link-check issue

### DIFF
--- a/src/geocat/comp/meteorology.py
+++ b/src/geocat/comp/meteorology.py
@@ -191,7 +191,7 @@ def _relhum(
 
      "Improved Magnus' Form Approx. of Saturation Vapor pressure"
      Oleg A. Alduchov and Robert E. Eskridge
-     https://doi.org/10.2172/548871
+     https://www.osti.gov/biblio/548871
 
     Parameters
     ----------
@@ -281,7 +281,7 @@ def _relhum_ice(t: typing.Union[np.ndarray, list, float],
 
     "Improved Magnus' Form Approx. of Saturation Vapor pressure"
     Oleg A. Alduchov and Robert E. Eskridge
-    https://doi.org/10.2172/548871
+    https://www.osti.gov/biblio/548871
 
     Parameters
     ----------
@@ -489,7 +489,7 @@ def _xrelhum(t: xr.DataArray, w: xr.DataArray, p: xr.DataArray) -> xr.DataArray:
 
      "Improved Magnus' Form Approx. of Saturation Vapor pressure"
      Oleg A. Alduchov and Robert E. Eskridge
-     https://doi.org/10.2172/548871
+     https://www.osti.gov/biblio/548871
 
     Parameters
     ----------
@@ -776,7 +776,7 @@ def relhum(
 
     "Improved Magnus' Form Approx. of Saturation Vapor pressure"
     Oleg A. Alduchov and Robert E. Eskridge
-    https://doi.org/10.2172/548871
+    https://www.osti.gov/biblio/548871
 
     Parameters
     ----------
@@ -832,7 +832,7 @@ def relhum(
         # set xarray attributes
         relative_humidity.attrs['long_name'] = "relative humidity"
         relative_humidity.attrs['units'] = 'percentage'
-        relative_humidity.attrs['info'] = 'https://doi.org/10.2172/548871'
+        relative_humidity.attrs['info'] = 'https://www.osti.gov/biblio/548871'
 
     else:
         # ensure in numpy array for function call
@@ -854,7 +854,7 @@ def relhum_ice(temperature: typing.Union[np.ndarray, list, float],
 
     "Improved Magnus' Form Approx. of Saturation Vapor pressure"
     Oleg A. Alduchov and Robert E. Eskridge
-    https://doi.org/10.2172/548871
+    https://www.osti.gov/biblio/548871
 
     Parameters
     ----------

--- a/src/geocat/comp/meteorology.py
+++ b/src/geocat/comp/meteorology.py
@@ -191,7 +191,7 @@ def _relhum(
 
      "Improved Magnus' Form Approx. of Saturation Vapor pressure"
      Oleg A. Alduchov and Robert E. Eskridge
-     https://doi.org/10.1175/1520-0450(1996)035<0601:IMFAOS>2.0.CO;2
+     https://journals.ametsoc.org/view/journals/apme/35/4/1520-0450_1996_035_0601_imfaos_2_0_co_2.xml
 
     Parameters
     ----------
@@ -489,7 +489,7 @@ def _xrelhum(t: xr.DataArray, w: xr.DataArray, p: xr.DataArray) -> xr.DataArray:
 
      "Improved Magnus' Form Approx. of Saturation Vapor pressure"
      Oleg A. Alduchov and Robert E. Eskridge
-     https://doi.org/10.1175/1520-0450(1996)035<0601:IMFAOS>2.0.CO;2
+     https://journals.ametsoc.org/view/journals/apme/35/4/1520-0450_1996_035_0601_imfaos_2_0_co_2.xml
 
     Parameters
     ----------
@@ -776,7 +776,7 @@ def relhum(
 
     "Improved Magnus' Form Approx. of Saturation Vapor pressure"
     Oleg A. Alduchov and Robert E. Eskridge
-    https://doi.org/10.1175/1520-0450(1996)035<0601:IMFAOS>2.0.CO;2
+    https://journals.ametsoc.org/view/journals/apme/35/4/1520-0450_1996_035_0601_imfaos_2_0_co_2.xml
 
     Parameters
     ----------
@@ -833,7 +833,7 @@ def relhum(
         relative_humidity.attrs['long_name'] = "relative humidity"
         relative_humidity.attrs['units'] = 'percentage'
         relative_humidity.attrs[
-            'info'] = 'https://doi.org/10.1175/1520-0450(1996)035<0601:IMFAOS>2.0.CO;2'
+            'info'] = 'https://journals.ametsoc.org/view/journals/apme/35/4/1520-0450_1996_035_0601_imfaos_2_0_co_2.xml'
 
     else:
         # ensure in numpy array for function call
@@ -855,7 +855,7 @@ def relhum_ice(temperature: typing.Union[np.ndarray, list, float],
 
     "Improved Magnus' Form Approx. of Saturation Vapor pressure"
     Oleg A. Alduchov and Robert E. Eskridge
-    https://doi.org/10.1175/1520-0450(1996)035<0601:IMFAOS>2.0.CO;2
+    https://journals.ametsoc.org/view/journals/apme/35/4/1520-0450_1996_035_0601_imfaos_2_0_co_2.xml
 
     Parameters
     ----------

--- a/src/geocat/comp/meteorology.py
+++ b/src/geocat/comp/meteorology.py
@@ -191,7 +191,7 @@ def _relhum(
 
      "Improved Magnus' Form Approx. of Saturation Vapor pressure"
      Oleg A. Alduchov and Robert E. Eskridge
-     https://www.osti.gov/biblio/548871
+     https://doi.org/10.1175/1520-0450(1996)035<0601:IMFAOS>2.0.CO;2
 
     Parameters
     ----------
@@ -281,7 +281,7 @@ def _relhum_ice(t: typing.Union[np.ndarray, list, float],
 
     "Improved Magnus' Form Approx. of Saturation Vapor pressure"
     Oleg A. Alduchov and Robert E. Eskridge
-    https://www.osti.gov/biblio/548871
+    https://doi.org/10.1175/1520-0450(1996)035<0601:IMFAOS>2.0.CO;2
 
     Parameters
     ----------
@@ -489,7 +489,7 @@ def _xrelhum(t: xr.DataArray, w: xr.DataArray, p: xr.DataArray) -> xr.DataArray:
 
      "Improved Magnus' Form Approx. of Saturation Vapor pressure"
      Oleg A. Alduchov and Robert E. Eskridge
-     https://www.osti.gov/biblio/548871
+     https://doi.org/10.1175/1520-0450(1996)035<0601:IMFAOS>2.0.CO;2
 
     Parameters
     ----------
@@ -776,7 +776,7 @@ def relhum(
 
     "Improved Magnus' Form Approx. of Saturation Vapor pressure"
     Oleg A. Alduchov and Robert E. Eskridge
-    https://www.osti.gov/biblio/548871
+    https://doi.org/10.1175/1520-0450(1996)035<0601:IMFAOS>2.0.CO;2
 
     Parameters
     ----------
@@ -832,7 +832,8 @@ def relhum(
         # set xarray attributes
         relative_humidity.attrs['long_name'] = "relative humidity"
         relative_humidity.attrs['units'] = 'percentage'
-        relative_humidity.attrs['info'] = 'https://www.osti.gov/biblio/548871'
+        relative_humidity.attrs[
+            'info'] = 'https://doi.org/10.1175/1520-0450(1996)035<0601:IMFAOS>2.0.CO;2'
 
     else:
         # ensure in numpy array for function call
@@ -854,7 +855,7 @@ def relhum_ice(temperature: typing.Union[np.ndarray, list, float],
 
     "Improved Magnus' Form Approx. of Saturation Vapor pressure"
     Oleg A. Alduchov and Robert E. Eskridge
-    https://www.osti.gov/biblio/548871
+    https://doi.org/10.1175/1520-0450(1996)035<0601:IMFAOS>2.0.CO;2
 
     Parameters
     ----------

--- a/src/geocat/comp/meteorology.py
+++ b/src/geocat/comp/meteorology.py
@@ -191,7 +191,6 @@ def _relhum(
 
      "Improved Magnus' Form Approx. of Saturation Vapor pressure"
      Oleg A. Alduchov and Robert E. Eskridge
-     http://www.osti.gov/scitech/servlets/purl/548871/
      https://doi.org/10.2172/548871
 
     Parameters
@@ -282,7 +281,6 @@ def _relhum_ice(t: typing.Union[np.ndarray, list, float],
 
     "Improved Magnus' Form Approx. of Saturation Vapor pressure"
     Oleg A. Alduchov and Robert E. Eskridge
-    http://www.osti.gov/scitech/servlets/purl/548871/
     https://doi.org/10.2172/548871
 
     Parameters
@@ -491,7 +489,6 @@ def _xrelhum(t: xr.DataArray, w: xr.DataArray, p: xr.DataArray) -> xr.DataArray:
 
      "Improved Magnus' Form Approx. of Saturation Vapor pressure"
      Oleg A. Alduchov and Robert E. Eskridge
-     http://www.osti.gov/scitech/servlets/purl/548871/
      https://doi.org/10.2172/548871
 
     Parameters
@@ -779,7 +776,6 @@ def relhum(
 
     "Improved Magnus' Form Approx. of Saturation Vapor pressure"
     Oleg A. Alduchov and Robert E. Eskridge
-    https://www.osti.gov/scitech/servlets/purl/548871/
     https://doi.org/10.2172/548871
 
     Parameters
@@ -858,7 +854,6 @@ def relhum_ice(temperature: typing.Union[np.ndarray, list, float],
 
     "Improved Magnus' Form Approx. of Saturation Vapor pressure"
     Oleg A. Alduchov and Robert E. Eskridge
-    http://www.osti.gov/scitech/servlets/purl/548871/
     https://doi.org/10.2172/548871
 
     Parameters

--- a/src/geocat/comp/meteorology.py
+++ b/src/geocat/comp/meteorology.py
@@ -281,7 +281,7 @@ def _relhum_ice(t: typing.Union[np.ndarray, list, float],
 
     "Improved Magnus' Form Approx. of Saturation Vapor pressure"
     Oleg A. Alduchov and Robert E. Eskridge
-    https://doi.org/10.1175/1520-0450(1996)035<0601:IMFAOS>2.0.CO;2
+    https://journals.ametsoc.org/view/journals/apme/35/4/1520-0450_1996_035_0601_imfaos_2_0_co_2.xml
 
     Parameters
     ----------


### PR DESCRIPTION
Resolves #307 

Issue was not with the link itself, but rather python trying to open an ssl connection with an incompatible cryptography package (I think)

Summary of changes:
- removes http://www.osti.gov/scitech/servlets/purl/548871 and https://doi.org/10.2172/548871, replaces with https://journals.ametsoc.org/view/journals/apme/35/4/1520-0450_1996_035_0601_imfaos_2_0_co_2.xml