### PR TITLE
Fix pint bug in showalter_index and deprecate

### DIFF
--- a/build_envs/docs.yml
+++ b/build_envs/docs.yml
@@ -9,7 +9,7 @@ dependencies:
     - geocat-viz
     - xarray
     - netcdf4
-    - pint<0.20
+    - pint
     - ipykernel
     - ipython
     - jupyter_client

--- a/build_envs/environment.yml
+++ b/build_envs/environment.yml
@@ -11,7 +11,7 @@ dependencies:
   - geocat-f2py
   - metpy
   - numpy
-  - pint<0.20           # pint 0.20+ currently breaks geocat-comp
+  - pint
   - xarray
   - xskillscore
 # Packages listed below are for testing

--- a/docs/user_api/index.rst
+++ b/docs/user_api/index.rst
@@ -59,7 +59,6 @@ Meteorology
    relhum_water
    saturation_vapor_pressure
    saturation_vapor_pressure_slope
-   showalter_index
 
 Spherical Harmonics
 ^^^^^^^^^^^^^^^^^^^
@@ -126,6 +125,15 @@ EOF Functions
 
    eofunc_eofs
    eofunc_pcs
+
+Meteorology
+^^^^^^^^^^^
+.. currentmodule:: geocat.comp.meteorology
+.. autosummary::
+   :nosignatures:
+   :toctree: ./generated/
+
+   showalter_index
 
 Polynomial
 ^^^^^^^^^^

--- a/src/geocat/comp/meteorology.py
+++ b/src/geocat/comp/meteorology.py
@@ -999,7 +999,11 @@ def showalter_index(
         pressure: typing.Union[pint.Quantity, list, float, int],
         temperature: typing.Union[pint.Quantity, list, float, int],
         dewpt: typing.Union[pint.Quantity, list, float, int]) -> pint.Quantity:
-    """Calculate Showalter Index from pressure temperature and 850 hPa lcl.
+    r"""
+    .. deprecated:: 2022.12.0 ``showalter_index`` is deprecated. Use ``metpy.calc.showalter_index``
+        instead. See the MetPy `documentation <https://unidata.github.io/MetPy/latest/api/generated/metpy.calc.showalter_index.html>`_.
+
+    Calculate Showalter Index from pressure temperature and 850 hPa lcl.
     Showalter Index derived from `Gallway 1956 <https://journals.ametsoc.org/do
     wnloadpdf/journals/bams/37/10/1520-0477-37_10_528.xml>`__.
 
@@ -1023,9 +1027,10 @@ def showalter_index(
     shox : :class:`pint.Quantity`
        Showalter index in delta degrees Celsius
     """
-    warnings.warn('showalter_index is deprecated in favor of metpy.calc.showalter_index',
-                  DeprecationWarning,
-                  stacklevel=2)
+    warnings.warn(
+        'showalter_index is deprecated in favor of metpy.calc.showalter_index',
+        DeprecationWarning,
+        stacklevel=2)
 
     ureg = pint.UnitRegistry()
     if not isinstance(pressure, pint.Quantity):

--- a/src/geocat/comp/meteorology.py
+++ b/src/geocat/comp/meteorology.py
@@ -1024,23 +1024,27 @@ def showalter_index(
 
     Returns
     -------
-    shox : :class:`pint.Quantity`
+    shox : same type as input
        Showalter index in delta degrees Celsius
+
+    Note
+    ----
+    ``pressure``, ``temperature``, and ``dewpt`` must all be ``pint.Quantity`` objects or all plain, unitless numbers.
     """
     warnings.warn(
         'showalter_index is deprecated in favor of metpy.calc.showalter_index',
         DeprecationWarning,
         stacklevel=2)
 
-    ureg = pint.UnitRegistry()
-    if not isinstance(pressure, pint.Quantity):
+    if not (isinstance(pressure, pint.Quantity)\
+            and isinstance(temperature, pint.Quantity)\
+            and isinstance(dewpt, pint.Quantity)):
         pressure = pressure * units.hPa
-    if not isinstance(temperature, pint.Quantity):
         temperature = temperature * units.degC
-    if not isinstance(dewpt, pint.Quantity):
         dewpt = dewpt * units.degC
-
-    return mpcalc.showalter_index(pressure, temperature, dewpt)
+        return mpcalc.showalter_index(pressure, temperature, dewpt).magnitude
+    else:
+        return mpcalc.showalter_index(pressure, temperature, dewpt)
 
 
 def max_daylight(

--- a/src/geocat/comp/meteorology.py
+++ b/src/geocat/comp/meteorology.py
@@ -1023,6 +1023,9 @@ def showalter_index(
     shox : :class:`pint.Quantity`
        Showalter index in delta degrees Celsius
     """
+    warn('showalter_index is deprecated in favor of metpy.calc.showalter_index',
+         DeprecationWarning,
+         stacklevel=2)
     if not isinstance(pressure, pint.Quantity):
         pressure = pint.Quantity(pressure, 'hPa')
     if not isinstance(temperature, pint.Quantity):

--- a/src/geocat/comp/meteorology.py
+++ b/src/geocat/comp/meteorology.py
@@ -1023,15 +1023,17 @@ def showalter_index(
     shox : :class:`pint.Quantity`
        Showalter index in delta degrees Celsius
     """
-    warn('showalter_index is deprecated in favor of metpy.calc.showalter_index',
-         DeprecationWarning,
-         stacklevel=2)
+    warnings.warn('showalter_index is deprecated in favor of metpy.calc.showalter_index',
+                  DeprecationWarning,
+                  stacklevel=2)
+
+    ureg = pint.UnitRegistry()
     if not isinstance(pressure, pint.Quantity):
-        pressure = pint.Quantity(pressure, 'hPa')
+        pressure = pint.Quantity(pressure, ureg.hPa)
     if not isinstance(temperature, pint.Quantity):
-        temperature = pint.Quantity(temperature, 'degC')
+        temperature = pint.Quantity(temperature, ureg.degC)
     if not isinstance(dewpt, pint.Quantity):
-        dewpt = pint.Quantity(dewpt, 'degC')
+        dewpt = pint.Quantity(dewpt, ureg.degC)
 
     return mpcalc.showalter_index(pressure, temperature, dewpt)
 

--- a/src/geocat/comp/meteorology.py
+++ b/src/geocat/comp/meteorology.py
@@ -1,6 +1,7 @@
 import dask.array as da
 import metpy.calc as mpcalc
 import numpy as np
+import pint
 import typing
 import warnings
 import xarray as xr

--- a/src/geocat/comp/meteorology.py
+++ b/src/geocat/comp/meteorology.py
@@ -995,8 +995,10 @@ def relhum_water(temperature: typing.Union[np.ndarray, list, float],
     return relative_humidity
 
 
-def showalter_index(pressure: pint.Quantity, temperature: pint.Quantity,
-                    dewpt: pint.Quantity) -> pint.Quantity:
+def showalter_index(
+        pressure: typing.Union[pint.Quantity, list, float, int],
+        temperature: typing.Union[pint.Quantity, list, float, int],
+        dewpt: typing.Union[pint.Quantity, list, float, int]) -> pint.Quantity:
     """Calculate Showalter Index from pressure temperature and 850 hPa lcl.
     Showalter Index derived from `Gallway 1956 <https://journals.ametsoc.org/do
     wnloadpdf/journals/bams/37/10/1520-0477-37_10_528.xml>`__.
@@ -1008,21 +1010,27 @@ def showalter_index(pressure: pint.Quantity, temperature: pint.Quantity,
 
     Parameters
     ----------
-    pressure : :class:`pint.Quantity`
+    pressure : :class:`pint.Quantity`, array-like, int, float
         Atmospheric pressure level(s) of interest, in order from highest
-        to lowest pressure
-    temperature : :class:`pint.Quantity`
-        Parcel temperature for corresponding pressure
-    dewpt : :class:`pint.Quantity`
-        Parcel dew point temperatures for corresponding pressure
+        to lowest pressure in hectoPascals
+    temperature : :class:`pint.Quantity`, array-like, int, float
+        Parcel temperature for corresponding pressure in degrees Celcius
+    dewpt : :class:`pint.Quantity`, array-like, int, float
+        Parcel dew point temperatures for corresponding pressure in degrees Celcius
 
     Returns
     -------
     shox : :class:`pint.Quantity`
-       Showalter index in delta degrees celsius
+       Showalter index in delta degrees Celsius
     """
-    shox = mpcalc.showalter_index(pressure, temperature, dewpt)
-    return shox
+    if not isinstance(pressure, pint.Quantity):
+        pressure = pint.Quantity(pressure, 'hPa')
+    if not isinstance(temperature, pint.Quantity):
+        temperature = pint.Quantity(temperature, 'degC')
+    if not isinstance(dewpt, pint.Quantity):
+        dewpt = pint.Quantity(dewpt, 'degC')
+
+    return mpcalc.showalter_index(pressure, temperature, dewpt)
 
 
 def max_daylight(

--- a/src/geocat/comp/meteorology.py
+++ b/src/geocat/comp/meteorology.py
@@ -1,7 +1,6 @@
 import dask.array as da
 import metpy.calc as mpcalc
 import numpy as np
-import pint.quantity
 import typing
 import warnings
 import xarray as xr

--- a/src/geocat/comp/meteorology.py
+++ b/src/geocat/comp/meteorology.py
@@ -1029,11 +1029,11 @@ def showalter_index(
 
     ureg = pint.UnitRegistry()
     if not isinstance(pressure, pint.Quantity):
-        pressure = pint.Quantity(pressure, ureg.hPa)
+        pressure = pressure * units.hPa
     if not isinstance(temperature, pint.Quantity):
-        temperature = pint.Quantity(temperature, ureg.degC)
+        temperature = temperature * units.degC
     if not isinstance(dewpt, pint.Quantity):
-        dewpt = pint.Quantity(dewpt, ureg.degC)
+        dewpt = dewpt * units.degC
 
     return mpcalc.showalter_index(pressure, temperature, dewpt)
 

--- a/src/geocat/comp/skewt_params.py
+++ b/src/geocat/comp/skewt_params.py
@@ -10,10 +10,9 @@ from .meteorology import showalter_index as showalter
 
 def showalter_index(pressure: pint.Quantity, temperature: pint.Quantity,
                     dewpt: pint.Quantity) -> pint.Quantity:
-    r""".. deprecated:: 2022.10.0 The ``skewt_params`` module is deprecated, and
-        ``showalter_index`` has been moved to the ``meteorology`` module for future
-        use. Use ``geocat.comp.showalter_index`` or ``geocat.comp.meteorology.showalter_index``
-        for the same functionality.
+    r""".. deprecated:: 2022.10.0 The ``skewt_params`` module is deprecated.
+        Use ``metpy.calc.showalter_index`` instead. See the MetPy
+        `documentation <https://unidata.github.io/MetPy/latest/api/generated/metpy.calc.showalter_index.html>`_.
 
     Calculate Showalter Index from pressure temperature and 850 hPa lcl.
     Showalter Index derived from `Gallway 1956 <https://journals.ametsoc.org/do

--- a/src/geocat/comp/skewt_params.py
+++ b/src/geocat/comp/skewt_params.py
@@ -2,7 +2,6 @@ from itertools import chain
 
 import metpy.calc as mpcalc
 import numpy as np
-import pint.quantity
 from metpy.units import units
 import warnings
 from .meteorology import showalter_index as showalter

--- a/src/geocat/comp/skewt_params.py
+++ b/src/geocat/comp/skewt_params.py
@@ -3,6 +3,7 @@ from itertools import chain
 import metpy.calc as mpcalc
 import numpy as np
 from metpy.units import units
+import pint
 import warnings
 from .meteorology import showalter_index as showalter
 

--- a/test/test_meteorology.py
+++ b/test/test_meteorology.py
@@ -319,15 +319,19 @@ class Test_showalter_index(unittest.TestCase):
     NCL_shox = int(Shox[0])  # Convert to int
 
     def test_shox_vals(self):
-        # Showalter index
-        shox = showalter_index(self.p, self.tc, self.tdc)
-        shox = shox[0].magnitude
+        parameters = [((self.p, self.tc, self.tdc), self.NCL_shox),
+                      ((self.p.magnitude, self.tc.magnitude,
+                        self.tdc.magnitude), self.NCL_shox)]
+        for params in parameters:
+            # Showalter index
+            shox = showalter_index(*params[0])
+            shox = shox[0].magnitude
 
-        # Place calculated values in iterable list
-        vals = np.round(shox).astype(int)
+            # Place calculated values in iterable list
+            vals = np.round(shox).astype(int)
 
-        # Compare calculated values with expected
-        np.testing.assert_equal(vals, self.NCL_shox)
+            # Compare calculated values with expected
+            np.testing.assert_equal(vals, params[1])
 
 
 class Test_actual_saturation_vapor_pressure(unittest.TestCase):

--- a/test/test_meteorology.py
+++ b/test/test_meteorology.py
@@ -12,16 +12,16 @@ import xarray as xr
 
 # Import from directory structure if coverage test, or from installed
 # packages otherwise
-#if "--cov" in str(sys.argv):
-from src.geocat.comp.meteorology import (
+if "--cov" in str(sys.argv):
+    from src.geocat.comp.meteorology import (
         dewtemp, heat_index, relhum, relhum_ice, relhum_water, showalter_index,
         actual_saturation_vapor_pressure, max_daylight, psychrometric_constant,
         saturation_vapor_pressure, saturation_vapor_pressure_slope)
-#else:
-#    from geocat.comp.meteorology import (
-#        dewtemp, heat_index, relhum, relhum_ice, relhum_water, showalter_index,
-#        actual_saturation_vapor_pressure, max_daylight, psychrometric_constant,
-#        saturation_vapor_pressure, saturation_vapor_pressure_slope)
+else:
+    from geocat.comp.meteorology import (
+        dewtemp, heat_index, relhum, relhum_ice, relhum_water, showalter_index,
+        actual_saturation_vapor_pressure, max_daylight, psychrometric_constant,
+        saturation_vapor_pressure, saturation_vapor_pressure_slope)
 
 
 class Test_dewtemp(unittest.TestCase):
@@ -320,7 +320,8 @@ class Test_showalter_index(unittest.TestCase):
 
     def test_shox_vals(self):
         self.assertWarns(DeprecationWarning)
-        parameters = [((self.p, self.tc, self.tdc), units.Quantity(self.NCL_shox, 'delta_degree_Celsius')),
+        parameters = [((self.p, self.tc, self.tdc),
+                       units.Quantity(self.NCL_shox, 'delta_degree_Celsius')),
                       ((self.p.magnitude, self.tc.magnitude,
                         self.tdc.magnitude), self.NCL_shox)]
         for params in parameters:

--- a/test/test_meteorology.py
+++ b/test/test_meteorology.py
@@ -12,16 +12,16 @@ import xarray as xr
 
 # Import from directory structure if coverage test, or from installed
 # packages otherwise
-if "--cov" in str(sys.argv):
-    from src.geocat.comp.meteorology import (
+#if "--cov" in str(sys.argv):
+from src.geocat.comp.meteorology import (
         dewtemp, heat_index, relhum, relhum_ice, relhum_water, showalter_index,
         actual_saturation_vapor_pressure, max_daylight, psychrometric_constant,
         saturation_vapor_pressure, saturation_vapor_pressure_slope)
-else:
-    from geocat.comp.meteorology import (
-        dewtemp, heat_index, relhum, relhum_ice, relhum_water, showalter_index,
-        actual_saturation_vapor_pressure, max_daylight, psychrometric_constant,
-        saturation_vapor_pressure, saturation_vapor_pressure_slope)
+#else:
+#    from geocat.comp.meteorology import (
+#        dewtemp, heat_index, relhum, relhum_ice, relhum_water, showalter_index,
+#        actual_saturation_vapor_pressure, max_daylight, psychrometric_constant,
+#        saturation_vapor_pressure, saturation_vapor_pressure_slope)
 
 
 class Test_dewtemp(unittest.TestCase):
@@ -320,13 +320,12 @@ class Test_showalter_index(unittest.TestCase):
 
     def test_shox_vals(self):
         self.assertWarns(DeprecationWarning)
-        parameters = [((self.p, self.tc, self.tdc), self.NCL_shox),
+        parameters = [((self.p, self.tc, self.tdc), units.Quantity(self.NCL_shox, 'delta_degree_Celsius')),
                       ((self.p.magnitude, self.tc.magnitude,
                         self.tdc.magnitude), self.NCL_shox)]
         for params in parameters:
             # Showalter index
             shox = showalter_index(*params[0])
-            shox = shox[0].magnitude
 
             # Place calculated values in iterable list
             vals = np.round(shox).astype(int)

--- a/test/test_meteorology.py
+++ b/test/test_meteorology.py
@@ -319,6 +319,7 @@ class Test_showalter_index(unittest.TestCase):
     NCL_shox = int(Shox[0])  # Convert to int
 
     def test_shox_vals(self):
+        self.assertWarns(DeprecationWarning)
         parameters = [((self.p, self.tc, self.tdc), self.NCL_shox),
                       ((self.p.magnitude, self.tc.magnitude,
                         self.tdc.magnitude), self.NCL_shox)]


### PR DESCRIPTION
Closes #305 
This PR patches a bug with `meteorology.showalter_index` that was causing issues with our CI. In addition, the function has been deprecated in favor of directly using `metpy.calc.showalter_index`.