### PR TITLE
Fix badge links

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,9 @@ If you use this software, please cite it as described at the [GeoCAT-comp - Cita
 https://geocat-comp.readthedocs.io/en/latest/citation.html) page.
 
 
-[github-ci-badge]: https://img.shields.io/github/workflow/status/NCAR/geocat-comp/CI?label=CI&style=for-the-badge
+[github-ci-badge]: https://img.shields.io/github/actions/workflow/status/NCAR/geocat-comp/ci.yml?branch=main&label=CI&style=for-the-badge
 [github-ci-link]: https://github.com/NCAR/geocat-comp/actions/workflows/ci.yml
-[github-upstream-ci-badge]: https://img.shields.io/github/workflow/status/NCAR/geocat-comp/Upstream-dev%20CI?label=Upstream-dev%20CI&style=for-the-badge
+[github-upstream-ci-badge]: https://img.shields.io/github/actions/workflow/status/NCAR/geocat-comp/upstream-dev-ci.yml?branch=main&label=Upstream%20CI&style=for-the-badge
 [github-upstream-ci-link]: https://github.com/NCAR/geocat-comp/actions/workflows/upstream-dev-ci.yml
 [codecov-badge]: https://img.shields.io/codecov/c/github/NCAR/geocat-comp.svg?logo=codecov&style=for-the-badge&color=brightgreen
 [codecov-link]: https://codecov.io/gh/NCAR/geocat-comp/coverage.yml


### PR DESCRIPTION
Closes #320 

Summary of changes:
- edits badge urls according to specifications in the badges/shields issue

See rendered README with changes [here](https://github.com/NCAR/geocat-comp/tree/badges#readme)
![image](https://user-images.githubusercontent.com/38434768/208174514-9b7ea3df-5aaf-49d2-acfe-d66b24358380.png)
