### PR TITLE
Pin numpy for numba compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Install geocat-comp
         run: |
           python -m pip install . --no-deps
-        
+
       - name: conda list
         run: |
           conda list

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,10 @@ jobs:
       - name: Install geocat-comp
         run: |
           python -m pip install . --no-deps
+        
+      - name: conda list
+        run: |
+          conda list
 
       - name: Run Namespace Tests
         run: |

--- a/.github/workflows/upstream-dev-ci.yml
+++ b/.github/workflows/upstream-dev-ci.yml
@@ -36,6 +36,10 @@ jobs:
       - name: Install geocat-comp
         run: |
           python -m pip install . --no-deps
+        
+      - name: conda list
+        run: |
+          conda list
 
       - name: Running Tests
         run: |

--- a/.github/workflows/upstream-dev-ci.yml
+++ b/.github/workflows/upstream-dev-ci.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install geocat-comp
         run: |
           python -m pip install . --no-deps
-        
+
       - name: conda list
         run: |
           conda list

--- a/build_envs/environment.yml
+++ b/build_envs/environment.yml
@@ -10,7 +10,8 @@ dependencies:
   - eofs
   - geocat-f2py
   - metpy
-  - numpy
+  - numba
+  - numpy<1.24
   - pint
   - xarray
   - xskillscore

--- a/build_envs/environment.yml
+++ b/build_envs/environment.yml
@@ -11,7 +11,7 @@ dependencies:
   - geocat-f2py
   - metpy
   - numba
-  - numpy<1.24
+  - numpy<1.24  # 1.24 not yet fully compatible with numba
   - pint
   - xarray
   - xskillscore


### PR DESCRIPTION
Closes #324 

Summary of changes:
- adds explicit numba dependency to environment.yml
- pins numpy in environment.yml to <1.24
- adds conda list step to CI and Upstream CI workflows for debugging in the future

Notes:
- we should be able to remove this pin on our side with the next numba release, as they have pinned it on their side upstream