### PR TITLE
Replace and deprecate `anomaly`

### DIFF
--- a/docs/user_api/index.rst
+++ b/docs/user_api/index.rst
@@ -12,9 +12,8 @@ Climatologies
    :nosignatures:
    :toctree: ./generated/
 
-   anomaly
    calendar_average
-   climatology
+   climate_anomaly
    climatology_average
    month_to_season
 
@@ -103,6 +102,16 @@ GeoCAT-comp routines from GeoCAT-f2py
 
 Deprecated Functions
 --------------------
+Climatologies
+^^^^^^^^^^^^^
+.. currentmodule:: geocat.comp.climatologies
+.. autosummary::
+   :nosignatures:
+   :toctree: ./generated/
+
+   anomaly
+   climatology
+
 Crop
 ^^^^
 .. currentmodule:: geocat.comp.crop

--- a/src/geocat/comp/__init__.py
+++ b/src/geocat/comp/__init__.py
@@ -1,5 +1,5 @@
 # move functions into geocat.comp namespace
-from .climatologies import anomaly, climatology, month_to_season, calendar_average, climatology_average
+from .climatologies import anomaly, climatology, month_to_season, calendar_average, climatology_average, climate_anomaly
 from .crop import (actual_saturation_vapor_pressure, max_daylight,
                    psychrometric_constant, saturation_vapor_pressure,
                    saturation_vapor_pressure_slope)

--- a/src/geocat/comp/climatologies.py
+++ b/src/geocat/comp/climatologies.py
@@ -388,7 +388,7 @@ def climate_anomaly(
     `calcMonAnomLLT <https://www.ncl.ucar.edu/Document/Functions/Contributed/calcMonAnomLLT.shtml>`__
     `calcMonAnomTLL <https://www.ncl.ucar.edu/Document/Functions/Contributed/calcMonAnomTLL.shtml>`__
     '''
-    # TODO add support for seasonal anomalies
+    # TODO add support for user specified seasons
     freq_dict = {
         'day': ('%m-%d', 'D'),
         'month': ('%m', 'MS'),
@@ -406,10 +406,13 @@ def climate_anomaly(
         clim = calendar_average(dset, freq, time_dim, keep_attrs)
     else:
         clim = climatology_average(dset, freq, time_dim, keep_attrs)
-
-    anom = dset.groupby(dset[time_dim].dt.strftime(format)) - clim.groupby(
-        clim[time_dim].dt.strftime(format)).sum()
-    return anom.drop_vars('strftime')
+    if freq == 'season':
+        anom = dset.groupby(f"{time_dim}.season") - clim
+        return anom
+    else:
+        anom = dset.groupby(dset[time_dim].dt.strftime(format)) - clim.groupby(
+            clim[time_dim].dt.strftime(format)).sum()
+        return anom.drop_vars('strftime')
 
 
 def month_to_season(

--- a/src/geocat/comp/climatologies.py
+++ b/src/geocat/comp/climatologies.py
@@ -338,7 +338,7 @@ def anomaly(
     data, time_invariant_vars, time_coord_name, time_dot_freq = _setup_clim_anom_input(
         dset, freq, time_coord_name)
 
-    clim = climatology_average(data, freq, time_coord_name)
+    clim = climatology(data, freq, time_coord_name)
     anom = data.groupby(time_dot_freq) - clim.groupby(time_dot_freq).sum()
     if time_invariant_vars:
         return xr.merge([dset[time_invariant_vars], anom])

--- a/src/geocat/comp/climatologies.py
+++ b/src/geocat/comp/climatologies.py
@@ -136,7 +136,13 @@ def climatology(
         freq: str,
         time_coord_name: str = None,
         keep_attrs: bool = None) -> typing.Union[xr.DataArray, xr.Dataset]:
-    """Compute climatologies for a specified time frequency.
+    r""".. deprecated:: 2023.02.0 The ``climatology`` function is deprecated due to
+        inaccuracies in monthly climatology calculations and when using monthly
+        data to calculate seasonal or yearly climatologies. Use
+        `climatology_average <https://geocat-comp.readthedocs.io/en/stable/user_api/generated/geocat.comp.climatologies.climatology_average.html>`__
+        instead.
+
+    Compute climatologies for a specified time frequency.
 
     Parameters
     ----------
@@ -213,6 +219,9 @@ def climatology(
 
     See Also
     --------
+    Related GeoCAT Functions:
+    `climatology_average <https://geocat-comp.readthedocs.io/en/stable/user_api/generated/geocat.comp.climatologies.climatology_average.html>`__
+
     Related NCL Functions:
     `clmDayTLL <https://www.ncl.ucar.edu/Document/Functions/Contributed/clmDayTLL.shtml>`__,
     `clmDayTLLL <https://www.ncl.ucar.edu/Document/Functions/Contributed/clmDayTLLL.shtml>`__,
@@ -244,7 +253,10 @@ def anomaly(
         dset: typing.Union[xr.DataArray, xr.Dataset],
         freq: str,
         time_coord_name: str = None) -> typing.Union[xr.DataArray, xr.Dataset]:
-    """Compute anomalies for a specified time frequency.
+    r""".. deprecated:: 2023.02.0 The ``anomaly`` function is deprecated due to
+        inaccuracies in monthly anomaly calculations and when using monthly
+        data to calculate seasonal or yearly anomalies. Use `climate_anomaly <https://geocat-comp.readthedocs.io/en/stable/user_api/generated/geocat.comp.climatologies.climate_anomaly.html>`__
+        instead.
 
     Parameters
     ----------
@@ -311,6 +323,9 @@ def anomaly(
 
     See Also
     --------
+    Related GeoCAT Functions:
+    `climate_anomaly <https://geocat-comp.readthedocs.io/en/stable/user_api/generated/geocat.comp.climatologies.climate_anomaly.html>`__
+
     Related NCL Functions:
     `clmDayAnomTLL <https://www.ncl.ucar.edu/Document/Functions/Contributed/calcDayAnomTLL.shtml>`__,
     `clmDayAnomTLLL <https://www.ncl.ucar.edu/Document/Functions/Contributed/calcMonAnomTLLL.shtml>`__,

--- a/src/geocat/comp/climatologies.py
+++ b/src/geocat/comp/climatologies.py
@@ -404,6 +404,7 @@ def climate_anomaly(
     `calcMonAnomTLL <https://www.ncl.ucar.edu/Document/Functions/Contributed/calcMonAnomTLL.shtml>`__
     '''
     # TODO add support for user specified seasons
+    time_dim = _get_time_coordinate_info(dset, time_dim)
     attrs = {}
     if keep_attrs or keep_attrs is None:
         attrs = dset.attrs

--- a/src/geocat/comp/climatologies.py
+++ b/src/geocat/comp/climatologies.py
@@ -323,13 +323,91 @@ def anomaly(
     data, time_invariant_vars, time_coord_name, time_dot_freq = _setup_clim_anom_input(
         dset, freq, time_coord_name)
 
-    clim = climatology(data, freq, time_coord_name)
-    anom = data.groupby(time_dot_freq) - clim
+    clim = climatology_average(data, freq, time_coord_name)
+    anom = data.groupby(time_dot_freq) - clim.groupby(time_dot_freq).sum()
     if time_invariant_vars:
         return xr.merge([dset[time_invariant_vars], anom])
     else:
         return anom
+def climate_anomaly(
+        dset: typing.Union[xr.DataArray, xr.Dataset],
+        freq: str,
+        time_dim: str = None,
+        keep_attrs: bool = 'default') -> typing.Union[xr.DataArray, xr.Dataset]:
+    '''This function calculates climate anomalies by subtracting the long term mean
+    of each `freq` period (day, month, season, or year) from each datapoint.
+    Parameters
+    ----------
+    dset : :class:`xarray.Dataset`, :class:`xarray.DataArray`
+        The data on which to operate. It must be uniformly spaced in the time
+        dimension.
 
+    freq : str
+        Frequency alias. When the `year` allias is used, the yearly average is
+        subtracted from each data point. Multiyear climatologies are not yet possible
+        with this function. Accepted alias:
+
+        - `day`: for anomalies from the daily climatology
+        - `month`: for anomalies from the monthly climatology
+        - `season`: for anomalies from the seasonal climatology (seasons are DJF, MAM, JJA, and SON)
+        - `year`: for anomalies from the yearly average
+
+    time_dim : str, optional
+        Name of the time coordinate for `xarray` objects. Defaults to ``None`` and
+        infers the name from the data.
+
+    keep_attrs : bool, optional
+        If True, attrs will be copied from the original object to the new one.
+        If False, the new object will be returned without attributes.
+        Defaults to None which means the attrs will only be kept in unambiguous circumstances.
+
+    Returns
+    -------
+    computed_dset : :class:`xarray.Dataset`, :class:`xarray.DataArray`
+        The computed data
+
+    Note
+    ----
+    Seasonal averages are weighted based on the number of days in each month.
+    This means that the given data must be uniformly spaced (i.e. data every 6
+    hours, every two days, every month, etc.) and must not cross month
+    boundaries (i.e. don't use weekly averages where the week falls in two
+    different months)
+
+    See Also
+    --------
+    Related GeoCAT Functions:
+    `climatology_average <https://geocat-comp.readthedocs.io/en/latest/user_api/generated/geocat.comp.climatologies.climatology_average.html#geocat.comp.climatologies.climatology_average>`__
+    `calendar_average <https://geocat-comp.readthedocs.io/en/latest/user_api/generated/geocat.comp.climatologies.calendar_average.html#geocat.comp.climatologies.calendar_average>`__
+
+    Related NCL Functions:
+    `calcDayAnomTLL <https://www.ncl.ucar.edu/Document/Functions/Contributed/calcDayAnomTLL.shtml>`__
+    `calcMonAnomLLLT <https://www.ncl.ucar.edu/Document/Functions/Contributed/calcMonAnomLLLT.shtml>`__
+    `calcMonAnomLLT <https://www.ncl.ucar.edu/Document/Functions/Contributed/calcMonAnomLLT.shtml>`__
+    `calcMonAnomTLL <https://www.ncl.ucar.edu/Document/Functions/Contributed/calcMonAnomTLL.shtml>`__
+    '''
+    # TODO add support for seasonal anomalies
+    freq_dict = {
+        'day': ('%m-%d', 'D'),
+        'month': ('%m', 'MS'),
+        'season': (None, 'QS-DEC'),
+        'year': ('%y', 'Y')
+    }
+
+    if freq not in freq_dict:
+        raise KeyError(
+            f"Received bad period {freq!r}. Expected one of {list(freq_dict.keys())!r}"
+        )
+    format, frequency = freq_dict[freq]
+
+    if freq=='year':
+        clim = calendar_average(dset, freq, time_dim, keep_attrs)
+    else:
+        clim = climatology_average(dset, freq, time_dim, keep_attrs)
+
+
+    anom =  dset.groupby(dset[time_dim].dt.strftime(format)) - clim.groupby(clim[time_dim].dt.strftime(format)).sum()
+    return anom.drop_vars('strftime')
 
 def month_to_season(
         dset: typing.Union[xr.Dataset, xr.DataArray],

--- a/src/geocat/comp/climatologies.py
+++ b/src/geocat/comp/climatologies.py
@@ -352,7 +352,8 @@ def climate_anomaly(
         time_dim: str = None,
         keep_attrs: bool = 'default') -> typing.Union[xr.DataArray, xr.Dataset]:
     '''This function calculates climate anomalies by subtracting the long term mean
-    of each `freq` period (day, month, season, or year) from each datapoint.
+    of each ``freq`` period (day, month, season, or year) from each datapoint.
+
     Parameters
     ----------
     dset : :class:`xarray.Dataset`, :class:`xarray.DataArray`
@@ -360,9 +361,9 @@ def climate_anomaly(
         dimension.
 
     freq : str
-        Frequency alias. When the `year` allias is used, the yearly average is
+        Frequency alias. When the ``'year'`` allias is used, the yearly average is
         subtracted from each data point. Multiyear climatologies are not yet possible
-        with this function. Accepted alias:
+        with this function. Accepted aliases:
 
         - `day`: for anomalies from the daily climatology
         - `month`: for anomalies from the monthly climatology
@@ -370,7 +371,7 @@ def climate_anomaly(
         - `year`: for anomalies from the yearly average
 
     time_dim : str, optional
-        Name of the time coordinate for `xarray` objects. Defaults to ``None`` and
+        Name of the time coordinate for ``xarray`` objects. Defaults to ``None`` and
         infers the name from the data.
 
     keep_attrs : bool, optional
@@ -381,7 +382,7 @@ def climate_anomaly(
     Returns
     -------
     computed_dset : :class:`xarray.Dataset`, :class:`xarray.DataArray`
-        The computed data
+        The computed anomalies
 
     Note
     ----

--- a/src/geocat/comp/climatologies.py
+++ b/src/geocat/comp/climatologies.py
@@ -329,6 +329,8 @@ def anomaly(
         return xr.merge([dset[time_invariant_vars], anom])
     else:
         return anom
+
+
 def climate_anomaly(
         dset: typing.Union[xr.DataArray, xr.Dataset],
         freq: str,
@@ -400,14 +402,15 @@ def climate_anomaly(
         )
     format, frequency = freq_dict[freq]
 
-    if freq=='year':
+    if freq == 'year':
         clim = calendar_average(dset, freq, time_dim, keep_attrs)
     else:
         clim = climatology_average(dset, freq, time_dim, keep_attrs)
 
-
-    anom =  dset.groupby(dset[time_dim].dt.strftime(format)) - clim.groupby(clim[time_dim].dt.strftime(format)).sum()
+    anom = dset.groupby(dset[time_dim].dt.strftime(format)) - clim.groupby(
+        clim[time_dim].dt.strftime(format)).sum()
     return anom.drop_vars('strftime')
+
 
 def month_to_season(
         dset: typing.Union[xr.Dataset, xr.DataArray],

--- a/src/geocat/comp/climatologies.py
+++ b/src/geocat/comp/climatologies.py
@@ -351,8 +351,9 @@ def climate_anomaly(
         freq: str,
         time_dim: str = None,
         keep_attrs: bool = 'default') -> typing.Union[xr.DataArray, xr.Dataset]:
-    '''This function calculates climate anomalies by subtracting the long term mean
-    of each ``freq`` period (day, month, season, or year) from each datapoint.
+    """This function calculates climate anomalies by subtracting the long term
+    mean of each ``freq`` period (day, month, season, or year) from each
+    datapoint.
 
     Parameters
     ----------
@@ -403,7 +404,7 @@ def climate_anomaly(
     `calcMonAnomLLLT <https://www.ncl.ucar.edu/Document/Functions/Contributed/calcMonAnomLLLT.shtml>`__
     `calcMonAnomLLT <https://www.ncl.ucar.edu/Document/Functions/Contributed/calcMonAnomLLT.shtml>`__
     `calcMonAnomTLL <https://www.ncl.ucar.edu/Document/Functions/Contributed/calcMonAnomTLL.shtml>`__
-    '''
+    """
     # TODO add support for user specified seasons
     time_dim = _get_time_coordinate_info(dset, time_dim)
     attrs = {}

--- a/src/geocat/comp/climatologies.py
+++ b/src/geocat/comp/climatologies.py
@@ -404,6 +404,10 @@ def climate_anomaly(
     `calcMonAnomTLL <https://www.ncl.ucar.edu/Document/Functions/Contributed/calcMonAnomTLL.shtml>`__
     '''
     # TODO add support for user specified seasons
+    attrs = {}
+    if keep_attrs or keep_attrs is None:
+        attrs = dset.attrs
+
     freq_dict = {
         'day': ('%m-%d', 'D'),
         'month': ('%m', 'MS'),
@@ -423,11 +427,11 @@ def climate_anomaly(
         clim = climatology_average(dset, freq, time_dim, keep_attrs)
     if freq == 'season':
         anom = dset.groupby(f"{time_dim}.season") - clim
-        return anom
+        return anom.assign_attrs(attrs)
     else:
         anom = dset.groupby(dset[time_dim].dt.strftime(format)) - clim.groupby(
             clim[time_dim].dt.strftime(format)).sum()
-        return anom.drop_vars('strftime')
+        return anom.drop_vars('strftime').assign_attrs(attrs)
 
 
 def month_to_season(

--- a/src/geocat/comp/climatologies.py
+++ b/src/geocat/comp/climatologies.py
@@ -339,7 +339,7 @@ def anomaly(
         dset, freq, time_coord_name)
 
     clim = climatology(data, freq, time_coord_name)
-    anom = data.groupby(time_dot_freq) - clim.groupby(time_dot_freq).sum()
+    anom = data.groupby(time_dot_freq) - clim
     if time_invariant_vars:
         return xr.merge([dset[time_invariant_vars], anom])
     else:

--- a/test/test_climatologies.py
+++ b/test/test_climatologies.py
@@ -158,10 +158,7 @@ class test_anomaly(unittest.TestCase):
 
 
 class test_climate_anomaly(unittest.TestCase):
-    minute = _get_dummy_data('2020-01-01', '2021-12-31 23:30:00', '30min', 1, 1)
-    hourly = _get_dummy_data('2020-01-01', '2021-12-31 23:00:00', 'H', 1, 1)
     daily = _get_dummy_data('2020-01-01', '2021-12-31', 'D', 1, 1)
-    monthly = _get_dummy_data('2020-01-01', '2021-12-01', 'MS', 1, 1)
 
     def test_daily_anomaly(self):
         expected_anom = np.concatenate([
@@ -285,6 +282,26 @@ class test_climate_anomaly(unittest.TestCase):
             attrs={'Description': 'This is dummy data for testing.'})
         anom = climate_anomaly(self.daily, 'year', time_dim='time')
         xarray.testing.assert_allclose(anom, expected_anom)
+
+    @parameterized.expand([('daily, "month", None', daily, 'month', None),
+                           ('daily, "month", True', daily, 'month', True),
+                           ('daily, "month", False', daily, 'month', False),
+                           ('daily, "season", None', daily, 'season', None),
+                           ('daily, "season", True', daily, 'season', True),
+                           ('daily, "season", False', daily, 'season', False),
+                           ('daily, "year", None', daily, 'year', None),
+                           ('daily, "year", True', daily, 'year', True),
+                           ('daily, "year", False', daily, 'year', False)
+                           ])
+    def test__keep_attrs(self, name, dset, freq, keep_attrs):
+        result = climate_anomaly(dset,
+                                 freq,
+                                 time_dim='time',
+                                 keep_attrs=keep_attrs)
+        if keep_attrs or keep_attrs == None:
+            assert result.attrs == dset.attrs
+        elif not keep_attrs:
+            assert result.attrs == {}
 
 
 class test_month_to_season(unittest.TestCase):

--- a/test/test_climatologies.py
+++ b/test/test_climatologies.py
@@ -231,6 +231,27 @@ class test_climate_anomaly(unittest.TestCase):
         anom = climate_anomaly(self.daily, 'month', time_dim='time')
         xarray.testing.assert_allclose(anom, expected_anom)
 
+    def test_yearly_anomaly(self):
+        expected_anom = np.concatenate([
+            np.arange(-182.5, 183),
+            np.arange(-182, 183)
+        ])
+        expected_anom = xr.Dataset(
+            data_vars={
+                'data': (('time', 'lat', 'lon'),
+                         np.reshape(expected_anom, (731, 1, 1)))
+            },
+            coords={
+                'time':
+                    xr.cftime_range(start='2020-01-01',
+                                    end='2021-12-31',
+                                    freq='D'),
+                'lat': [-90],
+                'lon': [-180]
+            },
+            attrs={'Description': 'This is dummy data for testing.'})
+        anom = climate_anomaly(self.daily, 'year', time_dim='time')
+        xarray.testing.assert_allclose(anom, expected_anom)
 
 class test_month_to_season(unittest.TestCase):
     ds1 = get_fake_dataset(start_month="2000-01", nmonths=12, nlats=1, nlons=1)

--- a/test/test_climatologies.py
+++ b/test/test_climatologies.py
@@ -293,7 +293,7 @@ class test_climate_anomaly(unittest.TestCase):
                            ('daily, "year", True', daily, 'year', True),
                            ('daily, "year", False', daily, 'year', False)
                            ])
-    def test__keep_attrs(self, name, dset, freq, keep_attrs):
+    def test_keep_attrs(self, name, dset, freq, keep_attrs):
         result = climate_anomaly(dset,
                                  freq,
                                  time_dim='time',

--- a/test/test_climatologies.py
+++ b/test/test_climatologies.py
@@ -163,7 +163,7 @@ class test_climate_anomaly(unittest.TestCase):
     monthly = _get_dummy_data('2020-01-01', '2021-12-01', 'MS', 1, 1)
 
     def test_daily_anomaly(self):
-        expected_anom = np.concatenate([np.full(59, -183), np.full(307, -182.5), np.full(59, 183), np.full(306, 182.5)])
+        expected_anom = np.concatenate([np.full(59, -183), [0], np.full(306, -182.5), np.full(59, 183), np.full(306, 182.5)])
         expected_anom = xr.Dataset(data_vars={'data': (('time', 'lat', 'lon'), np.reshape(expected_anom, (731, 1, 1)))},
                                    coords={
                                        'time': xr.cftime_range(start='2020-01-01', end='2021-12-31', freq='D'),
@@ -172,8 +172,6 @@ class test_climate_anomaly(unittest.TestCase):
                                    },
                                    attrs={'Description': 'This is dummy data for testing.'})
         anom = climate_anomaly(self.daily, 'day', time_dim='time')
-        print(anom.data.values)
-        print(expected_anom.data.values)
         xarray.testing.assert_allclose(anom, expected_anom)
 
 class test_month_to_season(unittest.TestCase):

--- a/test/test_climatologies.py
+++ b/test/test_climatologies.py
@@ -156,6 +156,7 @@ class test_anomaly(unittest.TestCase):
         computed_dset = anomaly(dataset, freq)
         assert type(dataset) == type(computed_dset)
 
+
 class test_climate_anomaly(unittest.TestCase):
     minute = _get_dummy_data('2020-01-01', '2021-12-31 23:30:00', '30min', 1, 1)
     hourly = _get_dummy_data('2020-01-01', '2021-12-31 23:00:00', 'H', 1, 1)
@@ -163,14 +164,26 @@ class test_climate_anomaly(unittest.TestCase):
     monthly = _get_dummy_data('2020-01-01', '2021-12-01', 'MS', 1, 1)
 
     def test_daily_anomaly(self):
-        expected_anom = np.concatenate([np.full(59, -183), [0], np.full(306, -182.5), np.full(59, 183), np.full(306, 182.5)])
-        expected_anom = xr.Dataset(data_vars={'data': (('time', 'lat', 'lon'), np.reshape(expected_anom, (731, 1, 1)))},
-                                   coords={
-                                       'time': xr.cftime_range(start='2020-01-01', end='2021-12-31', freq='D'),
-                                       'lat': [-90],
-                                       'lon': [-180]
-                                   },
-                                   attrs={'Description': 'This is dummy data for testing.'})
+        expected_anom = np.concatenate([
+            np.full(59, -183), [0],
+            np.full(306, -182.5),
+            np.full(59, 183),
+            np.full(306, 182.5)
+        ])
+        expected_anom = xr.Dataset(
+            data_vars={
+                'data': (('time', 'lat', 'lon'),
+                         np.reshape(expected_anom, (731, 1, 1)))
+            },
+            coords={
+                'time':
+                    xr.cftime_range(start='2020-01-01',
+                                    end='2021-12-31',
+                                    freq='D'),
+                'lat': [-90],
+                'lon': [-180]
+            },
+            attrs={'Description': 'This is dummy data for testing.'})
         anom = climate_anomaly(self.daily, 'day', time_dim='time')
         xarray.testing.assert_allclose(anom, expected_anom)
 

--- a/test/test_climatologies.py
+++ b/test/test_climatologies.py
@@ -181,7 +181,7 @@ class test_climate_anomaly(unittest.TestCase):
                 'lon': [-180]
             },
             attrs={'Description': 'This is dummy data for testing.'})
-        anom = climate_anomaly(self.daily, 'day', time_dim='time')
+        anom = climate_anomaly(self.daily, 'day')
         xarray.testing.assert_allclose(anom, expected_anom)
 
     def test_monthly_anomaly(self):
@@ -225,7 +225,7 @@ class test_climate_anomaly(unittest.TestCase):
                 'lon': [-180]
             },
             attrs={'Description': 'This is dummy data for testing.'})
-        anom = climate_anomaly(self.daily, 'month', time_dim='time')
+        anom = climate_anomaly(self.daily, 'month')
         xarray.testing.assert_allclose(anom, expected_anom)
 
     def test_seasonal_anomaly(self):
@@ -259,7 +259,7 @@ class test_climate_anomaly(unittest.TestCase):
                 'season': ('time', seasons)
             },
             attrs={'Description': 'This is dummy data for testing.'})
-        anom = climate_anomaly(self.daily, 'season', time_dim='time')
+        anom = climate_anomaly(self.daily, 'season')
         xarray.testing.assert_allclose(anom, expected_anom)
 
     def test_yearly_anomaly(self):
@@ -280,7 +280,7 @@ class test_climate_anomaly(unittest.TestCase):
                 'lon': [-180]
             },
             attrs={'Description': 'This is dummy data for testing.'})
-        anom = climate_anomaly(self.daily, 'year', time_dim='time')
+        anom = climate_anomaly(self.daily, 'year')
         xarray.testing.assert_allclose(anom, expected_anom)
 
     @parameterized.expand([('daily, "month", None', daily, 'month', None),
@@ -296,13 +296,59 @@ class test_climate_anomaly(unittest.TestCase):
     def test_keep_attrs(self, name, dset, freq, keep_attrs):
         result = climate_anomaly(dset,
                                  freq,
-                                 time_dim='time',
                                  keep_attrs=keep_attrs)
         if keep_attrs or keep_attrs == None:
             assert result.attrs == dset.attrs
         elif not keep_attrs:
             assert result.attrs == {}
 
+    def test_custom_time_dim(self):
+        time_dim = 'my_time'
+        expected_anom = np.concatenate([
+            np.arange(-198, -167),
+            np.arange(-193.54386, -165),
+            np.arange(-197.5, -166.5),
+            np.arange(-197, -167),
+            np.arange(-197.5, -166.5),
+            np.arange(-197, -167),
+            np.arange(-197.5, -166.5),
+            np.arange(-197.5, -166.5),
+            np.arange(-197, -167),
+            np.arange(-197.5, -166.5),
+            np.arange(-197, -167),
+            np.arange(-197.5, -166.5),
+            np.arange(168, 199),
+            np.arange(172.4561404, 200),
+            np.arange(167.5, 198.5),
+            np.arange(168, 198),
+            np.arange(167.5, 198.5),
+            np.arange(168, 198),
+            np.arange(167.5, 198.5),
+            np.arange(167.5, 198.5),
+            np.arange(168, 198),
+            np.arange(167.5, 198.5),
+            np.arange(168, 198),
+            np.arange(167.5, 198.5),
+        ])
+        expected_anom = xr.Dataset(
+            data_vars={
+                'data': ((time_dim, 'lat', 'lon'),
+                         np.reshape(expected_anom, (731, 1, 1)))
+            },
+            coords={
+                time_dim:
+                    xr.cftime_range(start='2020-01-01',
+                                    end='2021-12-31',
+                                    freq='D'),
+                'lat': [-90],
+                'lon': [-180]
+            },
+            attrs={'Description': 'This is dummy data for testing.'})
+
+        anom = climate_anomaly(self.daily.rename({'time': time_dim}),
+                                freq='month',
+                                time_dim=time_dim)
+        xr.testing.assert_allclose(anom, expected_anom)
 
 class test_month_to_season(unittest.TestCase):
     ds1 = get_fake_dataset(start_month="2000-01", nmonths=12, nlats=1, nlons=1)

--- a/test/test_climatologies.py
+++ b/test/test_climatologies.py
@@ -231,11 +231,46 @@ class test_climate_anomaly(unittest.TestCase):
         anom = climate_anomaly(self.daily, 'month', time_dim='time')
         xarray.testing.assert_allclose(anom, expected_anom)
 
-    def test_yearly_anomaly(self):
+    def test_seasonal_anomaly(self):
         expected_anom = np.concatenate([
-            np.arange(-182.5, 183),
-            np.arange(-182, 183)
+            np.arange(-320.9392265, -261),
+            np.arange(-228, -136),
+            np.arange(-228, -136),
+            np.arange(-227.5, -137),
+            np.arange(14.06077348, 104),
+            np.arange(137, 229),
+            np.arange(137, 229),
+            np.arange(137.5, 228),
+            np.arange(379.0607735, 410)
         ])
+        seasons = ['DJF'] * 60 + ['MAM'] * 92 + ['JJA'] * 92 + ['SON'] * 91 + [
+            'DFJ'
+        ] * 90 + ['MAM'] * 92 + ['JJA'] * 92 + ['SON'] * 91 + ['DJF'] * 31
+
+        expected_anom = xr.Dataset(
+            data_vars={
+                'data': (('time', 'lat', 'lon'),
+                         np.reshape(expected_anom, (731, 1, 1)))
+            },
+            coords={
+                'time':
+                    xr.cftime_range(start='2020-01-01',
+                                    end='2021-12-31',
+                                    freq='D'),
+                'lat': [-90],
+                'lon': [-180],
+                'season': ('time', seasons)
+            },
+            attrs={'Description': 'This is dummy data for testing.'})
+        anom = climate_anomaly(self.daily, 'season', time_dim='time')
+        print(anom.season, type(anom.season))
+        print(expected_anom.season, type(expected_anom.season))
+        xarray.testing.assert_allclose(anom, expected_anom)
+
+    def test_yearly_anomaly(self):
+        expected_anom = np.concatenate(
+            [np.arange(-182.5, 183),
+             np.arange(-182, 183)])
         expected_anom = xr.Dataset(
             data_vars={
                 'data': (('time', 'lat', 'lon'),
@@ -252,6 +287,7 @@ class test_climate_anomaly(unittest.TestCase):
             attrs={'Description': 'This is dummy data for testing.'})
         anom = climate_anomaly(self.daily, 'year', time_dim='time')
         xarray.testing.assert_allclose(anom, expected_anom)
+
 
 class test_month_to_season(unittest.TestCase):
     ds1 = get_fake_dataset(start_month="2000-01", nmonths=12, nlats=1, nlons=1)

--- a/test/test_climatologies.py
+++ b/test/test_climatologies.py
@@ -291,12 +291,9 @@ class test_climate_anomaly(unittest.TestCase):
                            ('daily, "season", False', daily, 'season', False),
                            ('daily, "year", None', daily, 'year', None),
                            ('daily, "year", True', daily, 'year', True),
-                           ('daily, "year", False', daily, 'year', False)
-                           ])
+                           ('daily, "year", False', daily, 'year', False)])
     def test_keep_attrs(self, name, dset, freq, keep_attrs):
-        result = climate_anomaly(dset,
-                                 freq,
-                                 keep_attrs=keep_attrs)
+        result = climate_anomaly(dset, freq, keep_attrs=keep_attrs)
         if keep_attrs or keep_attrs == None:
             assert result.attrs == dset.attrs
         elif not keep_attrs:
@@ -346,9 +343,10 @@ class test_climate_anomaly(unittest.TestCase):
             attrs={'Description': 'This is dummy data for testing.'})
 
         anom = climate_anomaly(self.daily.rename({'time': time_dim}),
-                                freq='month',
-                                time_dim=time_dim)
+                               freq='month',
+                               time_dim=time_dim)
         xr.testing.assert_allclose(anom, expected_anom)
+
 
 class test_month_to_season(unittest.TestCase):
     ds1 = get_fake_dataset(start_month="2000-01", nmonths=12, nlats=1, nlons=1)

--- a/test/test_climatologies.py
+++ b/test/test_climatologies.py
@@ -187,6 +187,51 @@ class test_climate_anomaly(unittest.TestCase):
         anom = climate_anomaly(self.daily, 'day', time_dim='time')
         xarray.testing.assert_allclose(anom, expected_anom)
 
+    def test_monthly_anomaly(self):
+        expected_anom = np.concatenate([
+            np.arange(-198, -167),
+            np.arange(-193.54386, -165),
+            np.arange(-197.5, -166.5),
+            np.arange(-197, -167),
+            np.arange(-197.5, -166.5),
+            np.arange(-197, -167),
+            np.arange(-197.5, -166.5),
+            np.arange(-197.5, -166.5),
+            np.arange(-197, -167),
+            np.arange(-197.5, -166.5),
+            np.arange(-197, -167),
+            np.arange(-197.5, -166.5),
+            np.arange(168, 199),
+            np.arange(172.4561404, 200),
+            np.arange(167.5, 198.5),
+            np.arange(168, 198),
+            np.arange(167.5, 198.5),
+            np.arange(168, 198),
+            np.arange(167.5, 198.5),
+            np.arange(167.5, 198.5),
+            np.arange(168, 198),
+            np.arange(167.5, 198.5),
+            np.arange(168, 198),
+            np.arange(167.5, 198.5),
+        ])
+        expected_anom = xr.Dataset(
+            data_vars={
+                'data': (('time', 'lat', 'lon'),
+                         np.reshape(expected_anom, (731, 1, 1)))
+            },
+            coords={
+                'time':
+                    xr.cftime_range(start='2020-01-01',
+                                    end='2021-12-31',
+                                    freq='D'),
+                'lat': [-90],
+                'lon': [-180]
+            },
+            attrs={'Description': 'This is dummy data for testing.'})
+        anom = climate_anomaly(self.daily, 'month', time_dim='time')
+        xarray.testing.assert_allclose(anom, expected_anom)
+
+
 class test_month_to_season(unittest.TestCase):
     ds1 = get_fake_dataset(start_month="2000-01", nmonths=12, nlats=1, nlons=1)
 

--- a/test/test_climatologies.py
+++ b/test/test_climatologies.py
@@ -244,7 +244,7 @@ class test_climate_anomaly(unittest.TestCase):
             np.arange(379.0607735, 410)
         ])
         seasons = ['DJF'] * 60 + ['MAM'] * 92 + ['JJA'] * 92 + ['SON'] * 91 + [
-            'DFJ'
+            'DJF'
         ] * 90 + ['MAM'] * 92 + ['JJA'] * 92 + ['SON'] * 91 + ['DJF'] * 31
 
         expected_anom = xr.Dataset(
@@ -263,8 +263,6 @@ class test_climate_anomaly(unittest.TestCase):
             },
             attrs={'Description': 'This is dummy data for testing.'})
         anom = climate_anomaly(self.daily, 'season', time_dim='time')
-        print(anom.season, type(anom.season))
-        print(expected_anom.season, type(expected_anom.season))
         xarray.testing.assert_allclose(anom, expected_anom)
 
     def test_yearly_anomaly(self):


### PR DESCRIPTION
Closes #265
This PR adds a new function called `climate_anomaly` which is meant to replace the old `anomaly` function. This replacement is happening because `anomaly` is based off of the older `climatology` which does not correctly weight monthly data. `climate_anomaly` relies on `climatology_average` and `calendar_average` which both correctly weight monthly data. `climate_anomaly` also has xarray attribute handling which `anomaly` did not have.

`anomaly` and `climatology` are both deprecated in this PR for future removal.