### PR TITLE
Allow upstream-dev to run on forks

### DIFF
--- a/.github/workflows/upstream-dev-ci.yml
+++ b/.github/workflows/upstream-dev-ci.yml
@@ -6,8 +6,6 @@ on:
 
 jobs:
   upstream-dev:
-    if: |
-      github.repository == 'NCAR/geocat-comp'
     name:  upstream-dev-py38
     runs-on: ubuntu-latest
     defaults:


### PR DESCRIPTION
Summary of changes:
- remove condition of only allowed to be run on NCAR/geocat-comp repo