### PR TITLE
Upstream CI

### DIFF
--- a/.github/workflows/upstream-dev-ci.yml
+++ b/.github/workflows/upstream-dev-ci.yml
@@ -33,13 +33,13 @@ jobs:
       - name: Install select upstream dependencies
         run: |
           pip install git+https://github.com/Unidata/MetPy.git
-          pip install https://github.com/numpy/numpy/archive/main.zip
-          pip install https://github.com/dask/dask/archive/main.zip
-          pip install https://github.com/dask/distributed/archive/main.zip
-          pip install https://github.com/hgrecco/pint/archive/main.zip
-          pip install https://github.com/pydata/xarray/archive/main.zip
-          pip install https://github.com/xarray-contrib/cf-xarray/archive/main.zip
-          pip install https://github.com/xarray-contrib/xskillscore/archive/main.zip
+          pip install git+https://github.com/numpy/numpy.git
+          pip install git+https://github.com/dask/dask.git
+          pip install git+https://github.com/dask/distributed.git
+          pip install git+https://github.com/hgrecco/pint.git
+          pip install git+https://github.com/pydata/xarray.git
+          pip installgit+https://github.com/xarray-contrib/cf-xarray.git
+          pip install git+https://github.com/xarray-contrib/xskillscore.git
 
       - name: Install conda dependencies
         run: |

--- a/.github/workflows/upstream-dev-ci.yml
+++ b/.github/workflows/upstream-dev-ci.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   upstream-dev:
-    name:  upstream-dev-py38
+    name:  upstream-dev-py310
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -24,12 +24,26 @@ jobs:
       - name: conda_setup
         uses: conda-incubator/setup-miniconda@v2
         with:
-          activate-environment: geocat_comp_build
+          activate-environment: geocat_comp_upstream
           channel-priority: strict
-          mamba-version: '*'
-          python-version: 3.8
+          miniconda-version: "latest"
+          python-version: "3.10"
           channels: conda-forge
-          environment-file: build_envs/upstream-dev-environment.yml
+
+      - name: Install select upstream dependencies
+        run: |
+          pip install https://github.com/Unidata/MetPy/archive/main.zip
+          pip install https://github.com/numpy/numpy/archive/main.zip
+          pip install https://github.com/dask/dask/archive/main.zip
+          pip install https://github.com/dask/distributed/archive/main.zip
+          pip install https://github.com/hgrecco/pint/archive/main.zip
+          pip install https://github.com/pydata/xarray/archive/main.zip
+          pip install https://github.com/xarray-contrib/cf-xarray/archive/main.zip
+          pip install https://github.com/xarray-contrib/xskillscore/archive/main.zip
+
+      - name: Install conda dependencies
+        run: |
+          conda env update --file build_envs/upstream-dev-environment.yml
 
       - name: Install geocat-comp
         run: |

--- a/.github/workflows/upstream-dev-ci.yml
+++ b/.github/workflows/upstream-dev-ci.yml
@@ -6,8 +6,6 @@ on:
 
 jobs:
   upstream-dev:
-    if: |
-      github.repository == 'NCAR/geocat-comp'
     name:  upstream-dev-py38
     runs-on: ubuntu-latest
     defaults:

--- a/.github/workflows/upstream-dev-ci.yml
+++ b/.github/workflows/upstream-dev-ci.yml
@@ -38,7 +38,7 @@ jobs:
           pip install git+https://github.com/dask/distributed.git
           pip install git+https://github.com/hgrecco/pint.git
           pip install git+https://github.com/pydata/xarray.git
-          pip installgit+https://github.com/xarray-contrib/cf-xarray.git
+          pip install git+https://github.com/xarray-contrib/cf-xarray.git
           pip install git+https://github.com/xarray-contrib/xskillscore.git
 
       - name: Install conda dependencies

--- a/.github/workflows/upstream-dev-ci.yml
+++ b/.github/workflows/upstream-dev-ci.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Install select upstream dependencies
         run: |
-          pip install https://github.com/Unidata/MetPy/archive/main.zip
+          pip install git+https://github.com/Unidata/MetPy.git
           pip install https://github.com/numpy/numpy/archive/main.zip
           pip install https://github.com/dask/dask/archive/main.zip
           pip install https://github.com/dask/distributed/archive/main.zip

--- a/build_envs/upstream-dev-environment.yml
+++ b/build_envs/upstream-dev-environment.yml
@@ -1,4 +1,4 @@
-name: geocat_comp_build
+name: geocat_comp_upstream
 channels:
   - conda-forge
 dependencies:
@@ -8,16 +8,6 @@ dependencies:
   - geocat-datafiles  # for tests
   - geocat-f2py
   - netcdf4  # for tests
-  - - parameterized  # for tests
+  - parameterized  # for tests
   - pytest  # for tests
   - pytest-cov  # for tests
-  - pip
-  - pip:
-    - git+https://github.com/Unidata/MetPy.git
-    - git+https://github.com/numpy/numpy.git
-    - git+https://github.com/dask/dask.git
-    - git+https://github.com/dask/distributed.git
-    - git+https://github.com/hgrecco/pint.git
-    - git+https://github.com/pydata/xarray.git
-    - git+https://github.com/xarray-contrib/cf-xarray.git
-    - git+https://github.com/xarray-contrib/xskillscore.git


### PR DESCRIPTION
Summary of changes:
- re-arrange order of action to set up conda, install pip dependencies, then install conda dependencies
- remove pip installs from conda env file
- switch to using miniconda instead of mamba
- rename the upstream dev environment to be distinct from the development environment
- update to run on python 3.10 instead of 3.8

See passing upstream CI here: https://github.com/anissa111/geocat-comp/actions/runs/4049852058