### PR TITLE
Add gradient function documentation to website

### DIFF
--- a/docs/internal_api/index.rst
+++ b/docs/internal_api/index.rst
@@ -23,6 +23,12 @@ Internal API
 
    geocat.comp.eofunc._generate_eofs_solver
 
+   geocat.comp.gradient._arc_lat_wgs84
+
+   geocat.comp.gradient._arc_lon_wgs84
+
+   geocat.comp.gradient._rad_lat_wgs84
+
    geocat.comp.interpolation._func_interpolate
 
    geocat.comp.interpolation._geo_height_extrapolate

--- a/docs/user_api/index.rst
+++ b/docs/user_api/index.rst
@@ -30,6 +30,15 @@ Fourier Filters
    fourier_high_pass
    fourier_low_pass
 
+Gradient
+^^^^^^^^
+.. currentmodule:: geocat.comp.gradient
+.. autosummary::
+   :nosignatures:
+   :toctree: ./generated/
+
+   gradient
+
 Iterpolation
 ^^^^^^^^^^^^
 .. currentmodule:: geocat.comp.interpolation

--- a/src/geocat/comp/__init__.py
+++ b/src/geocat/comp/__init__.py
@@ -7,7 +7,7 @@ from .eofunc import eofunc, eofunc_eofs, eofunc_pcs, eofunc_ts
 from .fourier_filters import (fourier_band_block, fourier_band_pass,
                               fourier_filter, fourier_high_pass,
                               fourier_low_pass)
-from .gradient import gradient, arc_lon_wgs84, arc_lat_wgs84, rad_lat_wgs84
+from .gradient import gradient, _arc_lon_wgs84, _arc_lat_wgs84, _rad_lat_wgs84
 from .interpolation import interp_hybrid_to_pressure, interp_sigma_to_hybrid, interp_multidim
 from .polynomial import detrend, ndpolyfit, ndpolyval
 from .meteorology import (dewtemp, heat_index, showalter_index, relhum,

--- a/src/geocat/comp/gradient.py
+++ b/src/geocat/comp/gradient.py
@@ -22,7 +22,7 @@ def _rad_lat_wgs84(lat: SupportedTypes,):
     Note
     ----
     This doesn't need to be a taylor series, though the taylor series
-    is faster and a needed step for the arc_lat_wgs84 function to avoid the
+    is faster and a needed step for the _arc_lat_wgs84 function to avoid the
     elliptic integral
 
     Parameters
@@ -149,7 +149,7 @@ def _arc_lon_wgs84(
     Note
     ----
     This doesn't need to be a taylor series, though the taylor series
-    is faster and a needed step for the arc_lat_wgs84 function to avoid the
+    is faster and a needed step for the _arc_lat_wgs84 function to avoid the
     elliptic integral
 
     Parameters
@@ -173,7 +173,7 @@ def _arc_lon_wgs84(
     `gradsg <https://www.ncl.ucar.edu/Document/Functions/Built-in/gradsg.shtml>`__
     """
 
-    return rad_lat_wgs84(lat) * np.cos(lat * d2r) * lon * d2r
+    return _rad_lat_wgs84(lat) * np.cos(lat * d2r) * lon * d2r
 
 
 def gradient(data: xr.DataArray) -> [xr.DataArray]:
@@ -202,12 +202,12 @@ def gradient(data: xr.DataArray) -> [xr.DataArray]:
     lon2d, lat2d = np.meshgrid(data.coords['lon'], data.coords['lat'])
 
     axis0loc = xr.DataArray(
-        arc_lat_wgs84(lat2d),
+        _arc_lat_wgs84(lat2d),
         coords=data.coords,
         dims=data.dims,
     )
     axis1loc = xr.DataArray(
-        arc_lon_wgs84(lon2d, lat2d),
+        _arc_lon_wgs84(lon2d, lat2d),
         coords=data.coords,
         dims=data.dims,
     )

--- a/src/geocat/comp/gradient.py
+++ b/src/geocat/comp/gradient.py
@@ -9,7 +9,7 @@ XTypes = Union[xr.DataArray, xr.Dataset]
 d2r = 1.74532925199432957692369e-02  # degrees to radians conversion factor
 
 
-def rad_lat_wgs84(lat: SupportedTypes,):
+def _rad_lat_wgs84(lat: SupportedTypes,):
     r"""The radius calculation for the wgs84 ellipsoid at a latitude uses a
     taylor series from.
 
@@ -69,7 +69,7 @@ def rad_lat_wgs84(lat: SupportedTypes,):
         6378137.0
 
 
-def arc_lat_wgs84(lat: SupportedTypes,):
+def _arc_lat_wgs84(lat: SupportedTypes,):
     r"""The arc length calculation for the wgs84 ellipsoid at a latitude uses a
     taylor series to obtain the value of the elliptic integral.
 
@@ -128,7 +128,7 @@ def arc_lat_wgs84(lat: SupportedTypes,):
         111319.490793273572647713 * lat
 
 
-def arc_lon_wgs84(
+def _arc_lon_wgs84(
     lon: SupportedTypes,
     lat: SupportedTypes,
 ):

--- a/src/geocat/comp/gradient.py
+++ b/src/geocat/comp/gradient.py
@@ -19,7 +19,9 @@ def _rad_lat_wgs84(lat: SupportedTypes,):
     This returns the radius of the ellipsoid for a given latitude
     This is accurate to within floating point error.
 
-    Note: This doesn't need to be a taylor series, though the taylor series
+    Note
+    ----
+    This doesn't need to be a taylor series, though the taylor series
     is faster and a needed step for the arc_lat_wgs84 function to avoid the
     elliptic integral
 
@@ -80,7 +82,9 @@ def _arc_lat_wgs84(lat: SupportedTypes,):
     This returns the distance from the equator to a given latitude
     This is accurate to within floating point error.
 
-    note: This needs to be a taylor series to avoid the elliptic integral
+    Note
+    ----
+    This needs to be a taylor series to avoid the elliptic integral
 
     Parameters
     ----------
@@ -142,7 +146,9 @@ def _arc_lon_wgs84(
     This returns the distance from the Greenwich Meridian to a given latitude
     This is accurate to within floating point error.
 
-    Note: This doesn't need to be a taylor series, though the taylor series
+    Note
+    ----
+    This doesn't need to be a taylor series, though the taylor series
     is faster and a needed step for the arc_lat_wgs84 function to avoid the
     elliptic integral
 


### PR DESCRIPTION
While working on the comp release, I noticed that the gradient.py functions were not included on the website. This PR fixes that