### PR TITLE
Create a utility function to generate docstrings on wrapper functions

### DIFF
--- a/docs/internal_api/index.rst
+++ b/docs/internal_api/index.rst
@@ -1,6 +1,16 @@
 Internal API
 ============
 
+Utility Functions
+-----------------
+.. autosummary::
+   :nosignatures:
+   :toctree: ./generated/
+
+   geocat.comp.gc_util._generate_wrapper_docstring
+
+Internal Functionality Helpers
+------------------------------
 .. autosummary::
    :nosignatures:
    :toctree: ./generated/

--- a/src/geocat/comp/gc_util.py
+++ b/src/geocat/comp/gc_util.py
@@ -1,0 +1,26 @@
+import typing
+
+
+def _generate_wrapper_docstring(wrapper_fcn: typing.Callable,
+                                base_fcn: typing.Callable) -> None:
+    """Generate the docstring for a wrapper function in the form of: 'This
+    method is a wrapper for base_fcn', with a generated link to the base
+    function.
+
+    Parameters
+    ----------
+    wrapper_fcn : function
+        The wrapper function to generate and assign a docstring
+
+    base_fcn : function
+        The wrapped function that the wrapper function's docstring is based
+        on and links to
+    """
+
+    # create wrapper docstring
+    wrapper_docstring = f".. attention:: This method is a wrapper for " \
+                        f":func:`{base_fcn.__name__} <{base_fcn.__module__}.{base_fcn.__name__}>`" \
+                        f"\n\n    {base_fcn.__doc__}"
+
+    # assign docstring to wrapper function
+    setattr(wrapper_fcn, '__doc__', wrapper_docstring)

--- a/src/geocat/comp/meteorology.py
+++ b/src/geocat/comp/meteorology.py
@@ -1,12 +1,10 @@
 import dask.array as da
-import metpy.calc as mpcalc
 import numpy as np
-import pint
 import typing
 import warnings
 import xarray as xr
-from itertools import chain
-from metpy.units import units
+
+from .gc_util import _generate_wrapper_docstring
 
 
 def _dewtemp(
@@ -1448,7 +1446,7 @@ def delta_pressure(pressure_lev, surface_pressure):
         The pressure level array. May be in ascending or descending order.
         Must have the same units as ``surface_pressure``.
 
-    surface_pressure : :class:`int`, :class:`float`, :class:`np.ndarray`, :class:`xr.DataArray`
+    surface_pressure : :class:`int`, :class:`float`, :class:`numpy.ndarray`, :class:`xarray.DataArray`
         The scalar or N-dimensional surface pressure array. Must have the same
         units as ``pressure_lev``.
 
@@ -1513,9 +1511,9 @@ def delta_pressure(pressure_lev, surface_pressure):
     return delta_pressure
 
 
+# NCL NAME WRAPPER FUNCTIONS BELOW
 def dpres_plev(pressure_lev, surface_pressure):
     return delta_pressure(pressure_lev, surface_pressure)
 
 
-_dpres_plev_doc_str = f".. attention:: This method is a wrapper for `delta_pressure <https://geocat-comp.readthedocs.io/en/stable/user_api/generated/geocat.comp.meteorology.delta_pressure.html>`_.\n\n    {delta_pressure.__doc__}"
-setattr(dpres_plev, '__doc__', _dpres_plev_doc_str)
+_generate_wrapper_docstring(dpres_plev, delta_pressure)


### PR DESCRIPTION
Closes #351 

## PR Summary
- Creates a `util.py` to house this and other future utility functions
- creates `_generate_wrapper_docstring()` utility function that generates sets the docstring on a wrapper function based on the base function docstring, which:
  - adds a caution admonition to the top of the docstring marking it as a wrapper function, 
  - links the base function
  - appends the original docstring
- makes a teeny edit on the delta_pressure docstring

## PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. If an entire section doesn't
apply to this PR, comment it out or delete it. -->
**General**
- [x] Make an issue if one doesn't already exist
- [x] Link the issue this PR resolves by adding `closes #XXX` to the PR description where XXX is the number of the issue.
- [x] Add appropriate labels to this PR
- [x] Make your changes in a forked repository rather than directly in this repo
- [x] Open this PR as a draft if it is not ready for review
- [x] Passes `precommit`. To set up on your local, run `pre-commit install` from the top level of the repository. To manually run pre-commits, use `pre-commit run --all-files` and re-add any changed files before committing again and pushing.

**Functionality**
- [x] Function is in appropriate module file
- [x] New function(s) intended for public API added to `src/geocat/comp/__init__.py` file

**Documentation**
- [x] Docstrings have been added to all new functions ([Documentation Standards](https://geocat.ucar.edu/pages/contributing.html#422-documentation))
- [N/A] Docstrings have updated with any function changes
- [x] Internal functions have a preceding underscore (`_`) and have been added to `docs/internal_api/index.rst`
- [N/A] User facing functions have been added to `docs/user_api/index.rst` under their module


<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://geocat.ucar.edu/pages/contributing.html.

- Fork this repository and open the PR from your fork. Do not directly work on
  the NCAR/geocat-comp repository.

- The PR title should summarize the changes, for example "Create weighted pearson-r
  correlation coefficient function". Avoid non-descriptive titles such as "Addresses
  issue #229".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

**PR Etiquette Reminders**
- This PR should be listed as a draft PR until you are ready to request reviewers

- After making changes in accordance with the reviews, re-request your reviewers

- Do *not* mark conversations as resolved if you didn't start them

- Do mark conversations as resolved *if you opened them* and are satisfied with the changes/discussion.

If you need assistance with your PR, please let the GeoCAT team know by
tagging us with @NCAR/geocat. We can help if reviews are unclear, the recommended changes
seem overly demanding, you would like help in addressing a reviewer's comments,
or if you have been waiting more than a week to hear back on your PR.
-->
