### PR TITLE
specify python 3.10 for pypi build

### DIFF
--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -11,7 +11,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4.5.0
         with:
-          python-version: '3.x'
+          python-version: '3.10'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -33,7 +33,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4.5.0
         with:
-          python-version: '3.x'
+          python-version: '3.10'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
## PR Summary
- specify python 3.10 for pypi release action. Currently it's trying to build with 3.11, which messes with our geocat-f2py dependency

## PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. If an entire section doesn't
apply to this PR, comment it out or delete it. -->
**General**
- 🤫 Make an issue if one doesn't already exist
- [x] Add appropriate labels to this PR
- [x] Make your changes in a forked repository rather than directly in this repo
- [x] Convert this PR from a draft to a full PR before requesting reviewers


<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://geocat.ucar.edu/pages/contributing.html.

- Fork this repository and open the PR from your fork. Do not directly work on
  the NCAR/geocat-comp repository.

- The PR title should summarize the changes, for example "Create weighted pearson-r
  correlation coefficient function". Avoid non-descriptive titles such as "Addresses
  issue #229".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

**PR Etiquette Reminders**
- This PR should be listed as a draft PR until you are ready to request reviewers

- After making changes in accordance with the reviews, re-request your reviewers

- Do *not* mark conversations as resolved if you didn't start them

- Do mark conversations as resolved *if you opened them* and are satisfied with the changes/discussion.

If you need assistance with your PR, please let the GeoCAT team know by
tagging us with @NCAR/geocat. We can help if reviews are unclear, the recommended changes
seem overly demanding, you would like help in addressing a reviewer's comments,
or if you have been waiting more than a week to hear back on your PR.
-->
