### PR TITLE
Limit pypi build to 3.10

### DIFF
--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -11,7 +11,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4.5.0
         with:
-          python-version: '3.x'
+          python-version: '3.10'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -33,7 +33,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4.5.0
         with:
-          python-version: '3.x'
+          python-version: '3.10'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
## PR Summary
Related to #391 
See also: #393

Summary of changes:
- turns out I was right about not using 3.11 in the pypi release action, just not for the issue I was trying to solve 

Note: I'm just going to admin merge this since this exact change was approved yesterday and I don't want to bother anyone this late