### PR TITLE
Release notes for v2023.05.0

### DIFF
--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -6,6 +6,11 @@ Release Notes
 
 v2023.05.0 (4 May 2023)
 -----------------------
+
+Plain text summary of significant changes
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+In this release, we've added support for numpy input and other improvements to the gradient function
+
 Bug Fixes
 ^^^^^^^^^
 * Support for numpy input types and lat/lon kwargs in gradient by `Julia Kent`_ and `Alea Kootz`_ in (:pr:`385`)
@@ -13,8 +18,6 @@ Bug Fixes
 Documentation
 ^^^^^^^^^^^^^
 * Update PR template to include manual addition to release notes by `Anissa Zacharias`_ in (:pr:`397`)
-
-**Full Changelog**: https://github.com/NCAR/geocat-comp/compare/v2023.03.2...v2023.05.0
 
 
 v2023.03.2 (Mar 29, 2023)

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -6,9 +6,6 @@ Release Notes
 
 v2023.05.0 (4 May 2023)
 -----------------------
-
-Plain text summary of significant changes
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 In this release, we've added support for numpy input and other improvements to the gradient function
 
 Bug Fixes

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -4,9 +4,8 @@
 Release Notes
 =============
 
-v2023.MM.00 (MM DD, YYYY)
--------------------------
-
+v2023.05.0 (4 May 2023)
+-----------------------
 Bug Fixes
 ^^^^^^^^^
 * Support for numpy input types and lat/lon kwargs in gradient by `Julia Kent`_ and `Alea Kootz`_ in (:pr:`385`)
@@ -14,6 +13,8 @@ Bug Fixes
 Documentation
 ^^^^^^^^^^^^^
 * Update PR template to include manual addition to release notes by `Anissa Zacharias`_ in (:pr:`397`)
+
+**Full Changelog**: https://github.com/NCAR/geocat-comp/compare/v2023.03.2...v2023.05.0
 
 
 v2023.03.2 (Mar 29, 2023)


### PR DESCRIPTION
# v2023.05.0 (4 May 2023)
## Bug Fixes
* Support for numpy input types and lat/lon kwargs in gradient by @jukent and @pilotchute in #385

## Documentation
* Update PR template to include manual addition to release notes by @anissa111 in #397

**Full Changelog**: https://github.com/NCAR/geocat-comp/compare/v2023.03.2...v2023.05.0

Closes #407

