### PR TITLE
Fix broken contributor's guide links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,3 @@
-Please first refer to [GeoCAT Contributor's Guide](https://geocat.ucar.edu/pages/contributing.html) for overall
-contribution guidelines (such as detailed description of GeoCAT structure, forking, repository cloning,
-branching, etc.). Once you determine that a function should be contributed under this repo, please refer to the
-following contribution guidelines:
-
 # Adding new functions to the Geocat-comp repo
 
 1. For a new function or family of functions that handle similar computations, create a new Python file in
@@ -11,7 +6,6 @@ following contribution guidelines:
 2. For implementation guidelines (such as Xarray and Dask usage), please refer to:
    - Previously implemented functionality as examples,
     e.g. [polynomial.py](https://github.com/NCAR/geocat-comp/blob/main/geocat/comp/polynomial.py) or others.
-   - [GeoCAT Contributor's Guide](https://geocat.ucar.edu/pages/contributing.html) for further information.
 
 3. In any Python script under `$GEOCATCOMP/geocat/comp/`, there may be user API functions, which are
 supposed to be included in the `geocat.comp` namespace, and internal API functions, which are used by the

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ however, developers are welcome to come up with novel computational functions fo
 
 [GeoCAT Homepage](https://geocat.ucar.edu/)
 
-[GeoCAT Contributor's Guide](https://geocat.ucar.edu/pages/contributing.html)
+[GeoCAT Contributor's Guide](https://github.com/NCAR/geocat-comp/blob/main/CONTRIBUTING.md)
 
 [GeoCAT-comp documentation on Read the Docs](https://geocat-comp.readthedocs.io)
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -90,7 +90,7 @@ novel computational functions for geosciences data.
    :caption: For Developers
 
    Release Notes <release-notes.rst>
-   Contributor's Guide <https://geocat.ucar.edu/pages/contributing.html>
+   Contributor's Guide <https://github.com/NCAR/geocat-comp/blob/main/CONTRIBUTING.md>
    Roadmap <https://geocat.ucar.edu/pages/roadmap.html>
 
 .. toctree::

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -5,9 +5,8 @@
 Installation
 ============
 
-This installation guide includes only the GeoCAT-comp installation and build instructions.
-Please refer to `GeoCAT Contributor's Guide <https://geocat.ucar.edu/pages/contributing.html>`__ for installation of
-the whole GeoCAT project.
+This installation guide includes only the GeoCAT-comp installation and build instructions. 
+Please refer to the relevant project documentation for how to install other GeoCAT packages.
 
 Installing GeoCAT-comp via Conda in a New Environment
 -----------------------------------------------------


### PR DESCRIPTION
## PR Summary
Point broken contributor's guide links to CONTRIBUTING.md instead and update corresponding surrounding text.

Note: I didn't add this to the release notes.  I figure we can do that once you get the updated guide in @anissa111.

Closes #443