### PR TITLE
Remove no longer need numpy version pin

### DIFF
--- a/build_envs/environment.yml
+++ b/build_envs/environment.yml
@@ -10,7 +10,7 @@ dependencies:
   - eofs
   - metpy
   - numba
-  - numpy<1.24  # 1.24 not yet fully compatible with numba
+  - numpy
   - pint
   - xarray<=2023.02.0 #pin per issue #381
   - xskillscore

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -5,9 +5,13 @@
 Release Notes
 =============
 
-v2023.11.1
+v2023.11.0 (unreleased)
 ----------
 This release ...
+
+Maintenance
+^^^^^^^^^^^
+* Remove no longer needed numpy version pin by `Katelyn FitzGerald`_ in (:pr:`515`)
 
 Documentation
 ^^^^^^^^^^^


### PR DESCRIPTION
## PR Summary
Remove numpy version pin since it is no longer needed for numba. 

Interestingly it was only in the environment.yml file. 

Closes #510

## PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. If an entire section doesn't
apply to this PR, comment it out or delete it. -->
**General**
- [x] Make an issue if one doesn't already exist
- [x] Link the issue this PR resolves by adding `closes #XXX` to the PR description where XXX is the number of the issue.
- [x] Add a brief summary of changes to `docs/release-notes.rst` in a relevant section for the next unreleased release. Possible sections include: Documentation, New Features, Bug Fixes, Internal Changes, Breaking Changes/Deprecated
- [x] Add appropriate labels to this PR
- [x] Make your changes in a forked repository rather than directly in this repo
- [x] Open this PR as a draft if it is not ready for review
- [x] Convert this PR from a draft to a full PR before requesting reviewers
- [x] Passes `precommit`. To set up on your local, run `pre-commit install` from the top level of the repository. To manually run pre-commits, use `pre-commit run --all-files` and re-add any changed files before committing again and pushing.
- [ ] If needed, squash and merge PR commits into a single commit to clean up commit history
