### PR TITLE
Fix extlinks formatting

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -111,8 +111,8 @@ intersphinx_mapping = {
 }
 # allows us to easily link PRs and issues in the change log
 extlinks = {
-    "issue": ("https://github.com/NCAR/geocat-comp/issues/%s", "GH"),
-    "pr": ("https://github.com/NCAR/geocat-comp/pull/%s", "PR"),
+    "issue": ("https://github.com/NCAR/geocat-comp/issues/%s", "GH%s"),
+    "pr": ("https://github.com/NCAR/geocat-comp/pull/%s", "PR%s"),
 }
 
 # napoleon settings

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -18,6 +18,7 @@ Internal Changes
 Bug Fixes
 ^^^^^^^^^
 * Unpin xarray in environment builds with changes to interpolation.py (specify dims in xr.DataArray) and climatologies.py (replace loffset with to_offset) by `Cora Schneck`_ in (:pr:`492`)
+* Fix `extlinks` for Sphinx 6 compatibility by `Anissa Zacharias`_ in (:pr:`520`)
 
 Maintenance
 ^^^^^^^^^^^


### PR DESCRIPTION
## PR Summary
<!-- Summary goes here. Replace XXX with the number of the issue this PR will resolve. -->
Closes #519

The docs error was not super helpful, but we just needed to add a corresponding `%s` to the second argument of our `extlinks` set up for sphinx 6+

## PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. If an entire section doesn't
apply to this PR, comment it out or delete it. -->
**General**
- [x] Make an issue if one doesn't already exist
- [x] Link the issue this PR resolves by adding `closes #XXX` to the PR description where XXX is the number of the issue.
- [x] Add a brief summary of changes to `docs/release-notes.rst` in a relevant section for the next unreleased release. Possible sections include: Documentation, New Features, Bug Fixes, Internal Changes, Breaking Changes/Deprecated
- [x] Add appropriate labels to this PR
- [x] Make your changes in a forked repository rather than directly in this repo
- [x] Passes `precommit`. To set up on your local, run `pre-commit install` from the top level of the repository. To manually run pre-commits, use `pre-commit run --all-files` and re-add any changed files before committing again and pushing.
- [ ] If needed, squash and merge PR commits into a single commit to clean up commit history
