### PR TITLE
Add retry step to linkcheck and CI

### DIFF
--- a/.github/workflows/asv-benchmarking.yml
+++ b/.github/workflows/asv-benchmarking.yml
@@ -61,7 +61,6 @@ jobs:
         with:
           timeout_minutes: 180
           max_attempts: 2
-          shell: bash -l {0}
           command: |
             eval "$(micromamba shell hook --shell bash)"
             micromamba activate

--- a/.github/workflows/asv-benchmarking.yml
+++ b/.github/workflows/asv-benchmarking.yml
@@ -37,7 +37,6 @@ jobs:
         uses: mamba-org/setup-micromamba@v1
         with:
           environment-file: ./build_envs/asv-bench.yml
-          environment-name: asv-bench
           cache-environment: true
           cache-environment-key: "benchmark-${{runner.os}}-${{runner.arch}}-${{env.TODAY}}"
 
@@ -47,7 +46,6 @@ jobs:
         with:
           download-micromamba: false
           environment-file: ./build_envs/asv-bench.yml
-          environment-name: asv-bench
           cache-environment: true
           cache-environment-key: "benchmark-${{runner.os}}-${{runner.arch}}-${{env.TODAY}}"
 

--- a/.github/workflows/asv-benchmarking.yml
+++ b/.github/workflows/asv-benchmarking.yml
@@ -56,12 +56,19 @@ jobs:
           fi
 
       - name: Run benchmarks
-        shell: bash -l {0}
         id: benchmark
-        run: |
-          cd benchmarks
-          asv machine --machine GH-Actions --os ubuntu-latest --arch x64 --cpu "2-core unknown" --ram 7GB
-          asv run v2023.02.0..main --skip-existing --parallel || true
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 180
+          max_attempts: 2
+          shell: bash -l {0}
+          command: |
+            eval "$(micromamba shell hook --shell bash)"
+            micromamba activate
+            micromamba acticate asv-bench
+            cd benchmarks
+            asv machine --machine GH-Actions --os ubuntu-latest --arch x64 --cpu "2-core unknown" --ram 7GB
+            asv run v2023.02.0..main --skip-existing --parallel || true
 
       - name: Commit and push benchmark results
         run: |

--- a/.github/workflows/asv-benchmarking.yml
+++ b/.github/workflows/asv-benchmarking.yml
@@ -56,18 +56,12 @@ jobs:
           fi
 
       - name: Run benchmarks
+        shell: bash -l {0}
         id: benchmark
-        uses: nick-fields/retry@v2
-        with:
-          timeout_minutes: 180
-          max_attempts: 2
-          command: |
-            eval "$(micromamba shell hook --shell bash)"
-            micromamba activate
-            micromamba acticate asv-bench
-            cd benchmarks
-            asv machine --machine GH-Actions --os ubuntu-latest --arch x64 --cpu "2-core unknown" --ram 7GB
-            asv run v2023.02.0..main --skip-existing --parallel || true
+        run: |
+          cd benchmarks
+          asv machine --machine GH-Actions --os ubuntu-latest --arch x64 --cpu "2-core unknown" --ram 7GB
+          asv run v2023.02.0..main --skip-existing --parallel || true
 
       - name: Commit and push benchmark results
         run: |

--- a/.github/workflows/asv-benchmarking.yml
+++ b/.github/workflows/asv-benchmarking.yml
@@ -32,8 +32,20 @@ jobs:
           echo "TODAY=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
 
       - name: Set up conda environment
+        id: env-setup
+        continue-on-error: true
         uses: mamba-org/setup-micromamba@v1
         with:
+          environment-file: ./build_envs/asv-bench.yml
+          environment-name: asv-bench
+          cache-environment: true
+          cache-environment-key: "benchmark-${{runner.os}}-${{runner.arch}}-${{env.TODAY}}"
+
+      - name: retry environment set up if failed
+        if: steps.env-setup.outcome == 'failure'
+        uses: mamba-org/setup-micromamba@v1
+        with:
+          download-micromamba: false
           environment-file: ./build_envs/asv-bench.yml
           environment-name: asv-bench
           cache-environment: true

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -1,11 +1,16 @@
-name: CI-release-test
+name: CI Release Test
 on:
   schedule:
     - cron: '0 0 * * *' # Daily “At 00:00”
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
+    if: github.repository == 'NCAR/geocat-comp' && github.ref == 'refs/heads/main'
     name: Python (${{ matrix.python-version }}, ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     defaults:
@@ -18,31 +23,29 @@ jobs:
         os: [ "ubuntu-latest", "macos-latest", "windows-latest" ]
         python-version: ["3.9", "3.10", "3.11"]
     steps:
-      - name: Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.12.0
-        with:
-          access_token: ${{ github.token }}
       - name: checkout
         uses: actions/checkout@v4
+      - name: environment set up
+        uses: mamba-org/setup-micromamba@v1
         with:
-          token: ${{ github.token }}
-      - name: conda_setup
-        uses: conda-incubator/setup-miniconda@v3
-        with:
-          channel-priority: strict
-          python-version: ${{ matrix.python-version }}
-          channels: conda-forge
+          environment-name: import_test
+          create-args: >-
+            python=${{ matrix.python-version }}
 
-      - name: Install released geocat-comp
+      - name: Try conda release
         run: |
-          conda create -n import_test geocat-comp
+          micromamba install geocat-comp
+          micromamba activate import_test
+          micromamba list
+          micromamba activate import_test
+          python -c "import geocat.comp"
 
-      - name: See environment info
+      - name: Uninstall conda release
         run: |
-          conda activate import_test
-          conda list
+          micromamba remove geocat-comp -y
 
-      - name: Import
+      - name: Try PyPI release
         run: |
-          conda activate import_test
+          pip install geocat-comp
+          micromamba list
           python -c "import geocat.comp"

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -39,6 +39,7 @@ jobs:
         if: steps.env-setup.outcome == 'failure'
         uses: mamba-org/setup-micromamba@v1
         with:
+          download-micromamba: false
           environment-name: import_test
           create-args: >-
             python=${{ matrix.python-version }}

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -25,7 +25,18 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
+
       - name: environment set up
+        id: env-setup
+        continue-on-error: true
+        uses: mamba-org/setup-micromamba@v1
+        with:
+          environment-name: import_test
+          create-args: >-
+            python=${{ matrix.python-version }}
+
+      - name: retry environment setup if failed
+        if: steps.env-setup.outcome == 'failure'
         uses: mamba-org/setup-micromamba@v1
         with:
           environment-name: import_test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,20 @@ jobs:
       - name: set environment variables
         run: |
           echo "TODAY=$(date +%Y-%m-%d)" >> $GITHUB_ENV
+
       - name: environment setup
+        id: env-setup
+        continue-on-error: true
+        uses: mamba-org/setup-micromamba@v1
+        with:
+          environment-file: build_envs/environment.yml
+          cache-environment: true
+          cache-environment-key: "CI ${{runner.os}}-${{runner.arch}}-py${{matrix.python-version}}-${{env.TODAY}}"
+          create-args: >-
+            python=${{matrix.python-version}}
+
+      - name: retry environment set up if failed
+        if: steps.env-setup.outcome == 'failure'
         uses: mamba-org/setup-micromamba@v1
         with:
           environment-file: build_envs/environment.yml
@@ -46,11 +59,29 @@ jobs:
         run: |
           python -m pip install --no-deps -e .
 
-      - name: Run Tests
-        run: python -m pytest test -v
-          --cov=./geocat/comp
-          --cov-report=xml
-          --junitxml=pytest.xml
+      - name: Run Tests (non-windows)
+        if: matrix.os != 'windows-latest'
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 60
+          max_attempts: 3
+          command: |
+            eval "$(micromamba shell hook --shell bash)"
+            micromamba activate
+            micromamba activate geocat_comp_build
+            python -m pytest test -v --cov=./geocat/comp --cov-report=xml --junitxml=pytest.xml
+
+      - name: Run Tests (windows)
+        if: matrix.os == 'windows-latest'
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 60
+          max_attempts: 3
+          command: |
+            micromamba.exe shell hook -s powershell | Out-String | Invoke-Expression
+            micromamba activate
+            micromamba activate geocat_comp_build
+            python -m pytest test -v --cov=./geocat/comp --cov-report=xml --junitxml=pytest.xml
 
       - name: Upload test results
         uses: actions/upload-artifact@v3
@@ -90,6 +121,13 @@ jobs:
         run: |
           conda list
       - name: Make docs with linkcheck
-        run: |
-          cd docs
-          make linkcheck
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 60
+          max_attempts: 3
+          command: |
+            eval "$(micromamba shell hook --shell bash)"
+            micromamba activate
+            micromamba activate gc-docs
+            cd docs
+            make linkcheck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
         if: steps.env-setup.outcome == 'failure'
         uses: mamba-org/setup-micromamba@v1
         with:
+          download-micromamba: false
           environment-file: build_envs/environment.yml
           cache-environment: true
           cache-environment-key: "CI ${{runner.os}}-${{runner.arch}}-py${{matrix.python-version}}-${{env.TODAY}}"
@@ -105,9 +106,23 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
+
       - name: environment setup
+        id: link-env-setup
+        continue-on-error: true
         uses: mamba-org/setup-micromamba@v1
         with:
+          environment-file: build_envs/docs.yml
+          cache-environment: true
+          cache-environment-key: "linkcheck-${{env.TODAY}}"
+          create-args: >-
+            python=3.11
+
+      - name: retry environment set up if failed
+        if: steps.link-env-setup.outcome == 'failure'
+        uses: mamba-org/setup-micromamba@v1
+        with:
+          download-micromamba: false
           environment-file: build_envs/docs.yml
           cache-environment: true
           cache-environment-key: "linkcheck-${{env.TODAY}}"

--- a/.github/workflows/upstream-dev-ci.yml
+++ b/.github/workflows/upstream-dev-ci.yml
@@ -59,6 +59,13 @@ jobs:
         run: |
           conda list
 
-      - name: Running Tests
-        run: |
-          python -m pytest test -v --cov=./geocat/comp --cov-report=xml
+      - name: Run Tests
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 60
+          max_attempts: 3
+          command: |
+            eval "$(micromamba shell hook --shell bash)"
+            micromamba activate
+            micromamba activate geocat_comp_build
+            python -m pytest test -v --cov=./geocat/comp --cov-report=xml

--- a/.github/workflows/upstream-dev-ci.yml
+++ b/.github/workflows/upstream-dev-ci.yml
@@ -35,16 +35,11 @@ jobs:
           create-args: >-
             python=${{ matrix.python-version }}
 
-      - name: remove existing micromamba if failed
-        if: steps.env-setup.outcome == 'failure'
-        run: |
-          micromamba deactivate
-          micromamba clean --all --yes
-
       - name: retry environment set up if failed
         if: steps.env-setup.outcome == 'failure'
         uses: mamba-org/setup-micromamba@v1
         with:
+          download-micromamba: false
           environment-file: build_envs/environment.yml
           create-args: >-
             python=${{ matrix.python-version }}

--- a/.github/workflows/upstream-dev-ci.yml
+++ b/.github/workflows/upstream-dev-ci.yml
@@ -31,9 +31,15 @@ jobs:
         continue-on-error: true
         uses: mamba-org/setup-micromamba@v1
         with:
-          environment-file: build_envs/environment-fake.yml
+          environment-file: build_envs/environment.yml
           create-args: >-
             python=${{ matrix.python-version }}
+
+      - name: remove existing micromamba if failed
+        if: steps.env-setup.outcome == 'failure'
+        run: |
+          micromamba deactivate
+          micromamba clean --all --yes
 
       - name: retry environment set up if failed
         if: steps.env-setup.outcome == 'failure'

--- a/.github/workflows/upstream-dev-ci.yml
+++ b/.github/workflows/upstream-dev-ci.yml
@@ -25,7 +25,18 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ github.token }}
+
       - name: set up environment
+        id: env-setup
+        continue-on-error: true
+        uses: mamba-org/setup-micromamba@v1
+        with:
+          environment-file: build_envs/environment.yml
+          create-args: >-
+            python=${{ matrix.python-version }}
+
+      - name: retry environment set up if failed
+        if: steps.env-setup.outcome == 'failure'
         uses: mamba-org/setup-micromamba@v1
         with:
           environment-file: build_envs/environment.yml

--- a/.github/workflows/upstream-dev-ci.yml
+++ b/.github/workflows/upstream-dev-ci.yml
@@ -31,7 +31,7 @@ jobs:
         continue-on-error: true
         uses: mamba-org/setup-micromamba@v1
         with:
-          environment-file: build_envs/environment-fake.yml
+          environment-file: build_envs/environment.yml
           create-args: >-
             python=${{ matrix.python-version }}
 

--- a/.github/workflows/upstream-dev-ci.yml
+++ b/.github/workflows/upstream-dev-ci.yml
@@ -31,7 +31,7 @@ jobs:
         continue-on-error: true
         uses: mamba-org/setup-micromamba@v1
         with:
-          environment-file: build_envs/environment.yml
+          environment-file: build_envs/environment-fake.yml
           create-args: >-
             python=${{ matrix.python-version }}
 

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -12,6 +12,7 @@ Internal Changes
 ^^^^^^^^^^^^^^^^
 * Upstream CI improvements by `Anissa Zacharias`_ in (:pr:`527`)
 * CI improvements by `Anissa Zacharias`_ in (:pr:`528`)
+* Add retry actions to CI by `Anissa Zacharias`_ in (:pr:`532`)
 
 
 v2023.12.0 (December 5, 2023)


### PR DESCRIPTION
## PR Summary
Adds a retry step around linkcheck and test commands
A reopen of #530
Depends on #528, #531
Closes #529 

See environment retry forced failure and secondary creation in [forked logs](https://github.com/anissa111/geocat-comp/actions/runs/7227528674/job/19695365028)

See retry action retrying (unsuccessfully, but still retrying anyway) in [these logs](https://github.com/NCAR/geocat-comp/actions/runs/7227015730/job/19693820844?pr=530)

## PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. If an entire section doesn't
apply to this PR, comment it out or delete it. -->
**General**
- [x] Make an issue if one doesn't already exist
- [x] Link the issue this PR resolves by adding `closes #XXX` to the PR description where XXX is the number of the issue.
- [x] Add a brief summary of changes to `docs/release-notes.rst` in a relevant section for the next unreleased release. Possible sections include: Documentation, New Features, Bug Fixes, Internal Changes, Breaking Changes/Deprecated
- [x] Add appropriate labels to this PR
- [x] Make your changes in a forked repository rather than directly in this repo
- [x] Passes `precommit`. To set up on your local, run `pre-commit install` from the top level of the repository. To manually run pre-commits, use `pre-commit run --all-files` and re-add any changed files before committing again and pushing.
- [x] If needed, squash and merge PR commits into a single commit to clean up commit history