### PR TITLE
Switch to PyPI Trusted Publishing

### DIFF
--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -28,6 +28,8 @@ jobs:
     needs: test-build
     if: startsWith(github.ref, 'refs/tags')
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -49,7 +49,5 @@ jobs:
       - name: Publish package to PyPI
         uses: pypa/gh-action-pypi-publish@v1.8.11
         with:
-          user: __token__
-          password: ${{ secrets.PYPI_PASSWORD }}
           skip_existing: true
           verbose: true

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -49,5 +49,5 @@ jobs:
       - name: Publish package to PyPI
         uses: pypa/gh-action-pypi-publish@v1.8.11
         with:
-          skip_existing: true
+          skip-existing: true
           verbose: true

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -12,6 +12,7 @@ Internal Changes
 ^^^^^^^^^^^^^^^^
 * Upstream CI improvements by `Anissa Zacharias`_ in (:pr:`527`)
 * CI improvements by `Anissa Zacharias`_ in (:pr:`528`)
+* Switch to PyPI Trusted Publishing by `Anissa Zacharias`_ in (:pr:`534`)
 
 
 v2023.12.0 (December 5, 2023)


### PR DESCRIPTION
## PR Summary
<!-- Summary goes here. Replace XXX with the number of the issue this PR will resolve. -->
Closes #533 

This PR just removes the user and password from the pypi action, but I've also added the workflow/repo as a trusted publisher on PyPI

<img width="731" alt="image" src="https://github.com/NCAR/geocat-comp/assets/38434768/b8fcd017-5c0e-44bc-8de6-a5a6f1435645">

I'm not exactly sure how to test this, but I'm pretty sure this is correct based [these docs](https://github.com/pypa/gh-action-pypi-publish/tree/v1.8.11/?tab=readme-ov-file#trusted-publishing).

## PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. If an entire section doesn't
apply to this PR, comment it out or delete it. -->
**General**
- [x] Make an issue if one doesn't already exist
- [x] Link the issue this PR resolves by adding `closes #XXX` to the PR description where XXX is the number of the issue.
- [x] Add a brief summary of changes to `docs/release-notes.rst` in a relevant section for the next unreleased release. Possible sections include: Documentation, New Features, Bug Fixes, Internal Changes, Breaking Changes/Deprecated
- [x] Add appropriate labels to this PR
- [x] Make your changes in a forked repository rather than directly in this repo
- [x] Passes `precommit`. To set up on your local, run `pre-commit install` from the top level of the repository. To manually run pre-commits, use `pre-commit run --all-files` and re-add any changed files before committing again and pushing.
- [x] If needed, squash and merge PR commits into a single commit to clean up commit history

