### PR TITLE
Add token to codecov upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,10 @@ jobs:
           path: pytest.xml
 
       - name: Upload code coverage to Codecov
+        if: github.repository == 'NCAR/geocat-comp'
         uses: codecov/codecov-action@v4.1.0
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           file: ./coverage.xml
           env_vars: OS,PYTHON

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -18,7 +18,7 @@ Internal Changes
 * Python 3.12 Support by `Cora Schneck`_ in (:pr:`548`)
 * Temporarily pin ASV to ``<0.6.2`` by `Anissa Zacharias`_ in (:pr:`556`)
 * Added ``linkcheck_ignore`` to ``docs/conf.py`` to address erroneous failures `Anissa Zacharias`_ in (:pr:`559`)
-
+* Updated Codecov upload to use token by `Anissa Zacharias`_ in (:pr:`566`)
 
 v2024.01.0 (January 30, 2023)
 -----------------------


### PR DESCRIPTION
## PR Summary
<!-- Summary goes here. Replace XXX with the number of the issue this PR will resolve. -->
Closes #565 

So, I'm not entirely sure how to test this because the failures only come from main on the NCAR/geocat-comp repo.

I followed this documentation from Codevoc: [Adding the Codecov Token](https://docs.codecov.com/docs/adding-the-codecov-token)

## PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. If an entire section doesn't
apply to this PR, comment it out or delete it. -->
**General**
- [x] Make an issue if one doesn't already exist
- [x] Link the issue this PR resolves by adding `closes #XXX` to the PR description where XXX is the number of the issue.
- [x] Add a brief summary of changes to `docs/release-notes.rst` in a relevant section for the next unreleased release. Possible sections include: Documentation, New Features, Bug Fixes, Internal Changes, Breaking Changes/Deprecated
- [x] Add appropriate labels to this PR
- [x] Make your changes in a forked repository rather than directly in this repo
- [x] Open this PR as a draft if it is not ready for review
- [x] Convert this PR from a draft to a full PR before requesting reviewers
- [x] Passes `precommit`. To set up on your local, run `pre-commit install` from the top level of the repository. To manually run pre-commits, use `pre-commit run --all-files` and re-add any changed files before committing again and pushing.
- [ ] If needed, squash and merge PR commits into a single commit to clean up commit history

