### PR TITLE
Add M1 runners to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "macos-latest", "windows-latest" ]
+        os: [ "ubuntu-latest", "macos-latest", "macos-14", "windows-latest" ]
         python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
       - name: checkout

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -12,6 +12,7 @@ Upcoming release
 Internal Changes
 ^^^^^^^^^^^^^
 * Additional pre-commit hook for codespell by `Cora Schneck`_ in (:pr:`579`)
+* Add M1 runners to CI by `Katelyn FitzGerald`_ in (:pr:`581`)
 
 v2024.02.0 (February 28, 2024)
 ------------------------------


### PR DESCRIPTION
## PR Summary
Adds M1 runners to CI.  

Closes #546

## PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. If an entire section doesn't
apply to this PR, comment it out or delete it. -->
**General**
- [ ] Make an issue if one doesn't already exist
- [ ] Link the issue this PR resolves by adding `closes #XXX` to the PR description where XXX is the number of the issue.
- [ ] Add a brief summary of changes to `docs/release-notes.rst` in a relevant section for the next unreleased release. Possible sections include: Documentation, New Features, Bug Fixes, Internal Changes, Breaking Changes/Deprecated
- [ ] Add appropriate labels to this PR
- [ ] Make your changes in a forked repository rather than directly in this repo
- [ ] Open this PR as a draft if it is not ready for review
- [ ] Convert this PR from a draft to a full PR before requesting reviewers
- [ ] Passes `precommit`. To set up on your local, run `pre-commit install` from the top level of the repository. To manually run pre-commits, use `pre-commit run --all-files` and re-add any changed files before committing again and pushing.
- [ ] If needed, squash and merge PR commits into a single commit to clean up commit history
