### PR TITLE
Address performance and deprecations in interp_hybrid_to_pressure

### DIFF
--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -5,6 +5,15 @@
 Release Notes
 =============
 
+v2024.04.0 (unreleased)
+-----------------------
+This release...
+
+Bug Fixes
+^^^^^^^^^
+* Fix to address slow execution times for ``interp_hybrid_to_pressure`` with extrapolation by `Katelyn FitzGerald`_ in (:pr:`592`)
+
+
 v2024.03.0 (March 29, 2024)
 ---------------------------
 This release includes a bug fix for ``delta_pressure``.

--- a/geocat/comp/interpolation.py
+++ b/geocat/comp/interpolation.py
@@ -464,7 +464,7 @@ def interp_hybrid_to_pressure(data: xr.DataArray,
         data = data.chunk(data_chunk)
 
     # Chunk pressure equal to data's chunks
-    pressure = pressure.chunk(data.chunks)
+    pressure = pressure.chunk(data_chunk)
 
     # Output data structure elements
     out_chunks = list(data.chunks)

--- a/geocat/comp/interpolation.py
+++ b/geocat/comp/interpolation.py
@@ -24,7 +24,7 @@ def _func_interpolate(method='linear'):
         func_interpolate = metpy.interpolate.log_interpolate_1d
     else:
         raise ValueError(f'Unknown interpolation method: {method}. '
-                        f'Supported methods are: "log" and "linear".')
+                         f'Supported methods are: "log" and "linear".')
 
     return func_interpolate
 
@@ -132,7 +132,8 @@ def _vertical_remap(func_interpolate, new_levels, xcoords, data, interp_axis=0):
     """Execute the defined interpolation function on data."""
 
     with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", r"Interpolation point out of data bounds encountered")
+        warnings.filterwarnings(
+            "ignore", r"Interpolation point out of data bounds encountered")
         return func_interpolate(new_levels, xcoords, data, axis=interp_axis)
 
 
@@ -289,7 +290,8 @@ def _vertical_remap_extrap(new_levels, lev_dim, data, output, pressure, ps,
         A DataArray containing the data after extrapolation.
     """
 
-    sfc_index = pressure[lev_dim].argmax(dim=lev_dim)  # index of the model surface
+    sfc_index = pressure[lev_dim].argmax(
+        dim=lev_dim)  # index of the model surface
     p_sfc = pressure.isel({lev_dim: sfc_index},
                           drop=True)  # extract pressure at lowest level
 

--- a/geocat/comp/interpolation.py
+++ b/geocat/comp/interpolation.py
@@ -469,7 +469,7 @@ def interp_hybrid_to_pressure(data: xr.DataArray,
         data = data.chunk(data_chunk)
 
     # Chunk pressure equal to data's chunks
-    pressure = pressure.chunk(data_chunk)
+    pressure = pressure.chunk(data.chunksizes)
 
     # Output data structure elements
     out_chunks = list(data.chunks)

--- a/geocat/comp/interpolation.py
+++ b/geocat/comp/interpolation.py
@@ -286,7 +286,7 @@ def _vertical_remap_extrap(new_levels, lev_dim, data, output, pressure, ps,
         A DataArray containing the data after extrapolation.
     """
 
-    sfc_index = pressure[lev_dim].argmax()  # index of the model surface
+    sfc_index = pressure[lev_dim].argmax(dim=lev_dim)  # index of the model surface
     p_sfc = pressure.isel({lev_dim: sfc_index},
                           drop=True)  # extract pressure at lowest level
 

--- a/geocat/comp/interpolation.py
+++ b/geocat/comp/interpolation.py
@@ -1,4 +1,5 @@
 import typing
+import warnings
 
 import cf_xarray
 import metpy.interpolate
@@ -23,7 +24,7 @@ def _func_interpolate(method='linear'):
         func_interpolate = metpy.interpolate.log_interpolate_1d
     else:
         raise ValueError(f'Unknown interpolation method: {method}. '
-                         f'Supported methods are: "log" and "linear".')
+                        f'Supported methods are: "log" and "linear".')
 
     return func_interpolate
 
@@ -130,7 +131,9 @@ def _sigma_from_hybrid(psfc, hya, hyb, p0=100000.):
 def _vertical_remap(func_interpolate, new_levels, xcoords, data, interp_axis=0):
     """Execute the defined interpolation function on data."""
 
-    return func_interpolate(new_levels, xcoords, data, axis=interp_axis)
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", r"Interpolation point out of data bounds encountered")
+        return func_interpolate(new_levels, xcoords, data, axis=interp_axis)
 
 
 def _temp_extrapolate(data, lev_dim, lev, p_sfc, ps, phi_sfc):


### PR DESCRIPTION
## PR Summary
Refactors the helper function `_vertical_remap_extrap` to avoid problematic for loops over the vertical levels and addresses some warnings related to specification of chunks, dimension specification with `argmax`, and intentional interpolation out of bounds.    

While this seems to address the most significant issues in terms of performance / execution time, there's still some clean up to be done in `interp_hybrid_to_pressure` and it would be nice to have a benchmark to cover this.

I did also replicate the poor performance with a larger example on my laptop in addition to the HPC system. 

Closes #591 

## PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. If an entire section doesn't
apply to this PR, comment it out or delete it. -->
**General**
- [x] Make an issue if one doesn't already exist
- [x] Link the issue this PR resolves by adding `closes #XXX` to the PR description where XXX is the number of the issue.
- [x] Add a brief summary of changes to `docs/release-notes.rst` in a relevant section for the next unreleased release. Possible sections include: Documentation, New Features, Bug Fixes, Internal Changes, Breaking Changes/Deprecated
- [x] Add appropriate labels to this PR
- [x] Make your changes in a forked repository rather than directly in this repo
- [x] Open this PR as a draft if it is not ready for review
- [x] Convert this PR from a draft to a full PR before requesting reviewers
- [x] Passes `precommit`. To set up on your local, run `pre-commit install` from the top level of the repository. To manually run pre-commits, use `pre-commit run --all-files` and re-add any changed files before committing again and pushing.
- [ ] If needed, squash and merge PR commits into a single commit to clean up commit history