### PR TITLE
Pin numpy<2.0 for PyPI install issue

### DIFF
--- a/build_envs/asv-bench.yml
+++ b/build_envs/asv-bench.yml
@@ -9,7 +9,7 @@ dependencies:
   - eofs
   - metpy
   - netcdf4
-  - numpy
+  - numpy<2.0
   - pint
   - pip
   - scipy

--- a/build_envs/environment.yml
+++ b/build_envs/environment.yml
@@ -10,7 +10,7 @@ dependencies:
   - eofs
   - metpy
   - numba
-  - numpy
+  - numpy<2.0
   - scipy
   - pandas
   - pint

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -13,6 +13,7 @@ This release...
 Bug Fixes
 ^^^^^^^^^
 * Fix to address slow execution times for ``interp_hybrid_to_pressure`` with extrapolation by `Katelyn FitzGerald`_ in (:pr:`592`)
+* Pin ``numpy<2.0`` for occasional PyPI install issues by `Anissa Zacharias`_ in (:pr:`600`)
 
 Compatibility
 ^^^^^^^^^^^^^

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ cftime
 dask[array]
 eofs
 metpy
-numpy
+numpy<2.0
 scipy
 xarray
 xskillscore

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@ setup_requires =
     pip
 install_requires =
     cf_xarray>=0.3.1
+    numpy<2.0
     cftime
     eofs
     metpy


### PR DESCRIPTION
## PR Summary
<!-- Summary goes here. Replace XXX with the number of the issue this PR will resolve. -->
Temporary fix for #598

So, due to a pip bug (see https://github.com/Unidata/cftime/issues/327), sometimes pre-release versions get installed, which is what's messing with our release tests. Since numpy 2.0 isn't actually released yet, I don't anticipate any problems with this pin until numpy 2.0 is fully released and generally compatible.

## PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. If an entire section doesn't
apply to this PR, comment it out or delete it. -->
**General**
- [x] Make an issue if one doesn't already exist
- [x] Link the issue this PR resolves by adding `closes #XXX` to the PR description where XXX is the number of the issue.
- [x] Add a brief summary of changes to `docs/release-notes.rst` in a relevant section for the next unreleased release. Possible sections include: Documentation, New Features, Bug Fixes, Internal Changes, Breaking Changes/Deprecated
- [x] Add appropriate labels to this PR
- [x] Make your changes in a forked repository rather than directly in this repo
- [x] Passes `precommit`. To set up on your local, run `pre-commit install` from the top level of the repository. To manually run pre-commits, use `pre-commit run --all-files` and re-add any changed files before committing again and pushing.
- [ ] If needed, squash and merge PR commits into a single commit to clean up commit history