### PR TITLE
Refactor ci-release.yml

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -10,6 +10,7 @@ concurrency:
 
 jobs:
   test_conda_release:
+    if: github.repository == 'NCAR/geocat-comp' && github.ref == 'refs/heads/main'
     name: Conda python${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     defaults:
@@ -18,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ "windows-latest", "ubuntu-latest", "macos-latest" ]
+        os: [ "ubuntu-latest", "macos-latest", "windows-latest" ]
         python-version: ["3.10", "3.11", "3.12"]
     steps:
       - name: checkout
@@ -46,7 +47,6 @@ jobs:
           cache-environment: true
           cache-environment-key: "release_test-${{runner.os}}-py${{matrix.python-version}}-${{steps.date.outputs.date}}"
 
-
       - name: Try conda release
         run: |
           micromamba install geocat-comp
@@ -56,6 +56,7 @@ jobs:
           python -c "import geocat.comp"
 
   test_pypi_release:
+    if: github.repository == 'NCAR/geocat-comp' && github.ref == 'refs/heads/main'
     name: PyPI python${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     defaults:
@@ -65,7 +66,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ "windows-latest", "ubuntu-latest", "macos-latest" ]
+        os: [ "ubuntu-latest", "macos-latest", "windows-latest" ]
         python-version: ["3.10", "3.11", "3.12"]
 
     steps:
@@ -91,11 +92,8 @@ jobs:
           cache-environment: true
           cache-environment-key: "release_test-${{runner.os}}-py${{matrix.python-version}}-${{steps.date.outputs.date}}"
 
-
       - name: Try PyPI release
         run: |
-          pip index versions geocat-comp
           pip install geocat-comp
-          which micromamba
           micromamba list
           python -c "import geocat.comp"

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -9,18 +9,16 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test:
-    if: github.repository == 'NCAR/geocat-comp' && github.ref == 'refs/heads/main'
-    name: Python (${{ matrix.python-version }}, ${{ matrix.os }})
+  test_conda_release:
+    name: Conda python${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     defaults:
       run:
         shell: bash -l {0}
-
     strategy:
       fail-fast: false
       matrix:
-        os: [ "ubuntu-latest", "macos-latest", "windows-latest" ]
+        os: [ "windows-latest", "ubuntu-latest", "macos-latest" ]
         python-version: ["3.10", "3.11", "3.12"]
     steps:
       - name: checkout
@@ -34,6 +32,8 @@ jobs:
           environment-name: import_test
           create-args: >-
             python=${{ matrix.python-version }}
+          cache-environment: true
+          cache-environment-key: "release_test-${{runner.os}}-py${{matrix.python-version}}-${{steps.date.outputs.date}}"
 
       - name: retry environment setup if failed
         if: steps.env-setup.outcome == 'failure'
@@ -43,6 +43,9 @@ jobs:
           environment-name: import_test
           create-args: >-
             python=${{ matrix.python-version }}
+          cache-environment: true
+          cache-environment-key: "release_test-${{runner.os}}-py${{matrix.python-version}}-${{steps.date.outputs.date}}"
+
 
       - name: Try conda release
         run: |
@@ -52,12 +55,47 @@ jobs:
           micromamba activate import_test
           python -c "import geocat.comp"
 
-      - name: Uninstall conda release
-        run: |
-          micromamba remove geocat-comp -y
+  test_pypi_release:
+    name: PyPI python${{ matrix.python-version }}, ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ "windows-latest", "ubuntu-latest", "macos-latest" ]
+        python-version: ["3.10", "3.11", "3.12"]
+
+    steps:
+      - name: environment set up
+        id: env-setup
+        continue-on-error: true
+        uses: mamba-org/setup-micromamba@v1
+        with:
+          environment-name: import_test
+          create-args: >-
+            python=${{ matrix.python-version }}
+          cache-environment: true
+          cache-environment-key: "release_test-${{runner.os}}-py${{matrix.python-version}}-${{steps.date.outputs.date}}"
+
+      - name: retry environment setup if failed
+        if: steps.env-setup.outcome == 'failure'
+        uses: mamba-org/setup-micromamba@v1
+        with:
+          download-micromamba: false
+          environment-name: import_test
+          create-args: >-
+            python=${{ matrix.python-version }}
+          cache-environment: true
+          cache-environment-key: "release_test-${{runner.os}}-py${{matrix.python-version}}-${{steps.date.outputs.date}}"
+
 
       - name: Try PyPI release
         run: |
+          pip index versions geocat-comp
           pip install geocat-comp
+          which micromamba
           micromamba list
           python -c "import geocat.comp"

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -20,6 +20,7 @@ Internal Changes
 * Remove ASV version pin and pin Conda version for benchmarking workflow by `Katelyn FitzGerald`_ in (:pr:`610`)
 * Updates to issue and PR templates by `Anissa Zacharias`_ in (:pr:`612`)
 * Re-pin ASV and list env info by `Katelyn FitzGerald`_ in (:pr:`613`)
+* Refactor ``pre-commit.ci`` by `Anissa Zacharias`_ in (:pr:`628`)
 
 v2024.04.0 (April 23, 2024)
 ---------------------------


### PR DESCRIPTION
## PR Summary
Nothing was wrong with the windows release, thankfully, it was a problem stemming from trying the pip install in the same environment that the conda version had been uninstalled from.

Changes:
- splits conda and pypi releases into two separate jobs
- adds pre-install environment cacheing

See [action run on my fork](https://github.com/anissa111/geocat-comp/actions/runs/9488707858/job/26148264321)

## Related Tickets & Documents
Closes #627

## PR Checklist
**General**
- [x] PR includes a summary of changes
- [x] Link relevant issues, make one if none exist
- [x] Add a brief summary of changes to `docs/release-notes.rst` in a relevant section for the upcoming release.
- [x] Add appropriate labels to this PR
- [x] PR follows the [Contributor's Guide](https://geocat-comp.readthedocs.io/en/stable/contrib.html)