### PR TITLE
Pinning micromamba for CI

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -31,6 +31,7 @@ jobs:
         continue-on-error: true
         uses: mamba-org/setup-micromamba@v1
         with:
+          micromamba-version: '1.5.10-0'
           environment-name: import_test
           create-args: >-
             python=${{ matrix.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
         continue-on-error: true
         uses: mamba-org/setup-micromamba@v1
         with:
+          micromamba-version: '1.5.10-0'
           environment-file: build_envs/environment.yml
           cache-environment: true
           cache-environment-key: "CI ${{runner.os}}-${{runner.arch}}-py${{matrix.python-version}}-${{env.TODAY}}"
@@ -49,6 +50,7 @@ jobs:
         if: steps.env-setup.outcome == 'failure'
         uses: mamba-org/setup-micromamba@v1
         with:
+          micromamba-version: '1.5.10-0'
           download-micromamba: false
           environment-file: build_envs/environment.yml
           cache-environment: true
@@ -92,7 +94,7 @@ jobs:
 
       - name: Upload code coverage to Codecov
         if: github.repository == 'NCAR/geocat-comp'
-        uses: codecov/codecov-action@v4.4.1
+        uses: codecov/codecov-action@v4.5.0
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,6 @@ jobs:
         if: steps.env-setup.outcome == 'failure'
         uses: mamba-org/setup-micromamba@v1
         with:
-          micromamba-version: '1.5.10-0'
           download-micromamba: false
           environment-file: build_envs/environment.yml
           cache-environment: true
@@ -117,6 +116,7 @@ jobs:
         continue-on-error: true
         uses: mamba-org/setup-micromamba@v1
         with:
+          micromamba-version: '1.5.10-0'
           environment-file: build_envs/docs.yml
           cache-environment: true
           cache-environment-key: "linkcheck-${{env.TODAY}}"

--- a/.github/workflows/upstream-dev-ci.yml
+++ b/.github/workflows/upstream-dev-ci.yml
@@ -31,6 +31,7 @@ jobs:
         continue-on-error: true
         uses: mamba-org/setup-micromamba@v1
         with:
+          micromamba-version: '1.5.10-0'
           environment-file: build_envs/environment.yml
           create-args: >-
             python=${{ matrix.python-version }}

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -20,6 +20,7 @@ Internal Changes
 * Remove ASV version pin and pin Conda version for benchmarking workflow by `Katelyn FitzGerald`_ in (:pr:`610`)
 * Updates to issue and PR templates by `Anissa Zacharias`_ in (:pr:`612`)
 * Re-pin ASV and list env info by `Katelyn FitzGerald`_ in (:pr:`613`)
+* Temporarily pin micromamba for CI by `Anissa Zacharias`_ in (:pr:`645`)
 
 v2024.04.0 (April 23, 2024)
 ---------------------------


### PR DESCRIPTION
## PR Summary
This PR adds a `micromamba-version: '1.5.10-0'` to the environment set up steps of:
- `.github/workflows/ci-release.yml`
- `.github/workflows/ci.yml`
- `.github/workflows/upstream-dev-ci.yml`

Note that this is not also done in the retry environment set up steps because we're specifically not downloading micromamba in those steps.

Along with this PR, I will also need to invalidate the existing caches to have this change work for workflows that have a cached environment (edit: done)

See [these logs](https://github.com/anissa111/geocat-comp/actions/runs/11024007886/job/30616398998) from my fork to see successful CI.

## PR Checklist
**General**
- [x] PR includes a summary of changes
- [n/a] Link relevant issues, make one if none exist
- [x] Add a brief summary of changes to `docs/release-notes.rst` in a relevant section for the upcoming release.
- [x] Add appropriate labels to this PR
- [x] PR follows the [Contributor's Guide](https://geocat-comp.readthedocs.io/en/stable/contrib.html)

