### PR TITLE
Remove NumPy version pin

### DIFF
--- a/build_envs/asv-bench.yml
+++ b/build_envs/asv-bench.yml
@@ -10,7 +10,7 @@ dependencies:
   - eofs
   - metpy
   - netcdf4
-  - numpy<2.0
+  - numpy
   - pint
   - pip
   - scipy<1.15

--- a/build_envs/environment.yml
+++ b/build_envs/environment.yml
@@ -10,7 +10,7 @@ dependencies:
   - eofs
   - metpy
   - numba
-  - numpy<2.0
+  - numpy
   - scipy<1.15
   - pandas
   - pint

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -8,6 +8,13 @@
 Release Notes
 =============
 
+vYYYY.MM.## (unreleased)
+------------------------
+
+Maintenance
+^^^^^^^^^^^
+* Remove NumPy version pin by `Katelyn FitzGerald`_ in (:pr:`686`)
+
 v2025.01.0 (January 28, 2025)
 -----------------------------
 v2025.01.0 releases a collection of small changes and pins ``scipy`` to <1.15

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ cftime
 dask[array]
 eofs
 metpy
-numpy<2.0
+numpy
 scipy<1.15
 xarray
 xskillscore

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ setup_requires =
     pip
 install_requires =
     cf_xarray>=0.3.1
-    numpy<2.0
+    numpy
     cftime
     eofs
     metpy


### PR DESCRIPTION
## PR Summary
Removes NumPy version pin leftover from environment issues when there was only a pre-release of NumPy 2.0 (see #600).

## Related Tickets & Documents
Closes #685

## PR Checklist
**General**
- [x] PR includes a summary of changes
- [x] Link relevant issues, make one if none exist
- [x] Add a brief summary of changes to `docs/release-notes.rst` in a relevant section for the upcoming release.
- [x] Add appropriate labels to this PR
- [x] PR follows the [Contributor's Guide](https://geocat-comp.readthedocs.io/en/stable/contrib.html)
