### PR TITLE
Python 3.13 support and testing

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ "ubuntu-latest", "macos-latest", "windows-latest" ]
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - name: checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ "ubuntu-latest", "macos-latest", "windows-latest" ]
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - name: checkout
         uses: actions/checkout@v4

--- a/build_envs/docs.yml
+++ b/build_envs/docs.yml
@@ -2,7 +2,7 @@ name: gc-docs
 channels:
     - conda-forge
 dependencies:
-    - python>=3.10,<3.13
+    - python>=3.10,<3.14
     - pre_commit
     - geocat-datafiles
     - geocat-viz

--- a/build_envs/environment.yml
+++ b/build_envs/environment.yml
@@ -2,7 +2,7 @@ name: geocat_comp_build
 channels:
   - conda-forge
 dependencies:
-  - python>=3.10,<3.13  # minimum support 3.10
+  - python>=3.10,<3.14  # minimum support 3.10
   - cf_xarray>=0.3.1    # min version 0.3.1 for dependencies
   - cftime
   - dask

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -13,6 +13,7 @@ vYYYY.MM.## (unreleased)
 
 Maintenance
 ^^^^^^^^^^^
+* Add support and testing for Python 3.13 by`Katelyn FitzGerald`_ in (:pr:`687`)
 * Remove NumPy version pin by `Katelyn FitzGerald`_ in (:pr:`686`)
 
 v2025.01.0 (January 28, 2025)

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,12 +18,13 @@ classifiers =
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Topic :: Scientific/Engineering
 
 [options]
 zip_safe = False
 include_package_data = True
-python_requires = >=3.10, <3.13
+python_requires = >=3.10, <3.14
 packages = find_namespace:
 setup_requires =
     setuptools_scm


### PR DESCRIPTION
## PR Summary
Bumps Python version pins to allow for Python 3.13 installs and adds Python 3.13 to testing.

Notably this doesn't bump Python versions for things like ASV and Codecov - not sure if we want to do that now as well.  

It also does not drop support for Python 3.10.  This means our testing matrix will get larger.  If that's an issue, we might think about testing min / max versions or at least not all versions on all platforms.  Dropping support for 3.10 right now seems a little soon.

## Related Tickets & Documents
Closes #675

## PR Checklist
**General**
- [x] PR includes a summary of changes
- [x] Link relevant issues, make one if none exist
- [x] Add a brief summary of changes to `docs/release-notes.rst` in a relevant section for the upcoming release.
- [x] Add appropriate labels to this PR
- [x] PR follows the [Contributor's Guide](https://geocat-comp.readthedocs.io/en/stable/contrib.html)
