### PR TITLE
Non nanosecond datetime tests

### DIFF
--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -11,9 +11,13 @@ Release Notes
 vYYYY.MM.## (unreleased)
 ------------------------
 
+Enhancements
+^^^^^^^^^^^^
+* Add tests and support for non-nanosecond datetime objects by `Katelyn FitzGerald`_ in (:pr:`691`)
+
 Maintenance
 ^^^^^^^^^^^
-* Add support and testing for Python 3.13 by`Katelyn FitzGerald`_ in (:pr:`687`)
+* Add support and testing for Python 3.13 by `Katelyn FitzGerald`_ in (:pr:`687`)
 * Remove NumPy version pin by `Katelyn FitzGerald`_ in (:pr:`686`)
 
 v2025.01.0 (January 28, 2025)

--- a/geocat/comp/climatologies.py
+++ b/geocat/comp/climatologies.py
@@ -105,7 +105,8 @@ def _infer_calendar_name(dates):
     anytime. It was copied to preserve the version that is compatible with
     functions in climatologies.py
     """
-    if np.asarray(dates).dtype == "datetime64[ns]":
+
+    if np.issubdtype(dates.dtype, np.datetime64):
         return "proleptic_gregorian"
     else:
         return np.asarray(dates).ravel()[0].calendar

--- a/test/test_climatologies.py
+++ b/test/test_climatologies.py
@@ -6,6 +6,7 @@ import xarray.testing
 import xarray as xr
 
 from geocat.comp import climate_anomaly, month_to_season, calendar_average, climatology_average
+from geocat.comp.climatologies import _infer_calendar_name
 
 
 ##### Helper Functions #####
@@ -943,3 +944,8 @@ class Test_Climatology_Average():
                                                         expected) -> None:
         result = climatology_average(dset, freq='month')
         xr.testing.assert_allclose(result, expected)
+
+@pytest.mark.parametrize("units", ("s", "ms", "us", "ns"))
+def test_units_infer_calendar_name(units):
+    time = xr.date_range("2000-01-01", periods=10, freq="1D", unit=units)
+    assert _infer_calendar_name(time) == "proleptic_gregorian"

--- a/test/test_climatologies.py
+++ b/test/test_climatologies.py
@@ -945,6 +945,7 @@ class Test_Climatology_Average():
         result = climatology_average(dset, freq='month')
         xr.testing.assert_allclose(result, expected)
 
+
 @pytest.mark.parametrize("units", ("s", "ms", "us", "ns"))
 def test_units_infer_calendar_name(units):
     time = xr.date_range("2000-01-01", periods=10, freq="1D", unit=units)


### PR DESCRIPTION
## PR Summary
Minor changes to an internal helper function in climatologies borrowed from Xarray in order to support non-nanosecond datetime objects.  The alternative would be to user the corresponding function from Xarray, but it's a bit more complex now (spanning multiple modules) and still private API.  

Thankfully we don't have that much date/time handling code in comp at this point (we mostly rely on xarray and friends) so it should just be this change that's needed.

Added test coverage as well. 

## Related Tickets & Documents
Closes #682

## PR Checklist
**General**
- [x] PR includes a summary of changes
- [x] Link relevant issues, make one if none exist
- [x] Add a brief summary of changes to `docs/release-notes.rst` in a relevant section for the upcoming release.
- [x] Add appropriate labels to this PR
- [x] PR follows the [Contributor's Guide](https://geocat-comp.readthedocs.io/en/stable/contrib.html)

**Testing**
- [x] Update or create tests in appropriate test file


