### PR TITLE
Minimum dependency version testing and backwards compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
   test:
     # if: |
     #   github.repository == 'NCAR/geocat-comp'
-    name: Python (${{ matrix.python-version }}, ${{ matrix.os }})
+    name: Python ${{ matrix.python-version }}, ${{ matrix.os }}, ${{ matrix.env }}
     runs-on: ${{ matrix.os }}
     defaults:
       run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
   test:
     # if: |
     #   github.repository == 'NCAR/geocat-comp'
-    name: Python ${{ matrix.python-version }}, ${{ matrix.os }}, ${{ matrix.env }}
+    name: Python ${{ matrix.python-version }} ${{ matrix.os }} ${{ matrix.env }}
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -98,7 +98,7 @@ jobs:
       - name: Upload test results
         uses: actions/upload-artifact@v4
         with:
-          name: Test results for ${{ runner.os }}-${{ matrix.python-version }}
+          name: Test results for ${{ runner.os }}-${{ matrix.python-version }} ${{ matrix.env }}
           path: pytest.xml
 
       - name: Upload code coverage to Codecov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ "ubuntu-latest", "macos-latest", "windows-latest" ]
+        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
         python-version: ["3.10", "3.11", "3.12", "3.13"]
+        env: [""]
+        include:
+          - env: "min-deps"
+            python-version: "3.10"
+            os: ubuntu-latest
     steps:
       - name: checkout
         uses: actions/checkout@v4
@@ -34,12 +39,18 @@ jobs:
         run: |
           echo "TODAY=$(date +%Y-%m-%d)" >> $GITHUB_ENV
 
+          if [[ "${{ matrix.env }}" == "min-deps" ]]; then
+             echo "CONDA_ENV_FILE=build_envs/min-deps.yml" >> $GITHUB_ENV
+          else
+             echo "CONDA_ENV_FILE=build_envs/environment.yml" >> $GITHUB_ENV
+          fi
+
       - name: environment setup
         id: env-setup
         continue-on-error: true
         uses: mamba-org/setup-micromamba@v2
         with:
-          environment-file: build_envs/environment.yml
+          environment-file: ${{ env.CONDA_ENV_FILE }}
           cache-environment: true
           cache-environment-key: "CI ${{runner.os}}-${{runner.arch}}-py${{matrix.python-version}}-${{env.TODAY}}"
           create-args: >-
@@ -50,7 +61,7 @@ jobs:
         uses: mamba-org/setup-micromamba@v2
         with:
           download-micromamba: false
-          environment-file: build_envs/environment.yml
+          environment-file: ${{ env.CONDA_ENV_FILE }}
           cache-environment: true
           cache-environment-key: "CI ${{runner.os}}-${{runner.arch}}-py${{matrix.python-version}}-${{env.TODAY}}"
           create-args: >-

--- a/build_envs/min-deps.yml
+++ b/build_envs/min-deps.yml
@@ -10,11 +10,16 @@ dependencies:
   - distributed
   - eofs
   - metpy
+  - netcdf4
   - numpy=1.25
   - packaging
   - pandas=2.0
   - scipy=1.11
   - xarray
+  - xskillscore
   - pip
+  - parameterized
+  - pre-commit
   - pytest
   - pytest-cov
+  - geocat-datafiles

--- a/build_envs/min-deps.yml
+++ b/build_envs/min-deps.yml
@@ -1,0 +1,20 @@
+name: geocat_comp_build
+channels:
+  - conda-forge
+  - nodefaults
+dependencies:
+  - python=3.10
+  - cf_xarray
+  - cftime
+  - dask-core
+  - distributed
+  - eofs
+  - metpy
+  - numpy=1.25
+  - packaging
+  - pandas=2.0
+  - scipy=1.11
+  - xarray=2023.3
+  - pip
+  - pytest
+  - pytest-cov

--- a/build_envs/min-deps.yml
+++ b/build_envs/min-deps.yml
@@ -14,7 +14,7 @@ dependencies:
   - packaging
   - pandas=2.0
   - scipy=1.11
-  - xarray=2023.3
+  - xarray
   - pip
   - pytest
   - pytest-cov

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -11,6 +11,11 @@ Release Notes
 vYYYY.MM.## (unreleased)
 ------------------------
 
+Enhancements
+^^^^^^^^^^^^
+* Add minimum dependency version testing and address minor compatibility issues with Pandas and Xarray by
+`Katelyn FitzGerald`_ in (:pr:`699`)
+
 Internal Changes
 ^^^^^^^^^^^^^^^^
 * Reconfigure analytics by `Katelyn FitzGerald`_ in (:pr:`698`)

--- a/geocat/comp/climatologies.py
+++ b/geocat/comp/climatologies.py
@@ -309,10 +309,10 @@ def month_to_season(
     if isinstance(means.indexes[time_coord_name],
                   xr.coding.cftimeindex.CFTimeIndex):
         means[time_coord_name] = means.indexes[
-            time_coord_name] + xr.coding.cftime_offsets.to_offset(freq="MS")
+            time_coord_name] + xr.coding.cftime_offsets.to_offset("MS")
     elif isinstance(means.indexes[time_coord_name], pd.DatetimeIndex):
         means[time_coord_name] = means.indexes[
-            time_coord_name] + pd.tseries.frequencies.to_offset(freq="MS")
+            time_coord_name] + pd.tseries.frequencies.to_offset("MS")
     else:
         raise ValueError(
             f"unsupported array type - {type(means.indexes[time_coord_name])}. Valid types include: (xr.coding.cftimeindex.CFTimeIndex, pandas.core.indexes.datetimes.DatetimeIndex)"

--- a/test/test_climatologies.py
+++ b/test/test_climatologies.py
@@ -948,5 +948,5 @@ class Test_Climatology_Average():
 
 @pytest.mark.parametrize("units", ("s", "ms", "us", "ns"))
 def test_units_infer_calendar_name(units):
-    time = xr.date_range("2000-01-01", periods=10, freq="1D", unit=units)
+    time = pd.date_range("2000-01-01", periods=10, freq="1D", unit=units)
     assert _infer_calendar_name(time) == "proleptic_gregorian"


### PR DESCRIPTION
## PR Summary
Adds a minimum dependency environment file and testing to CI and makes a few minor changes for backwards compatibility with earlier versions of Pandas and Xarray to climatology functions and associated testing.  I thought about separating those out into their own PR, but the changes are quite minor.

What's missing:
* documentation for users + devs
* minimum versions in our dependency specification

I'm open to adding these now, but wonder if it might make sense to hold off a bit in case we opt to make changes (e.g. include other packages, change versions, etc.).  Also, I'm not aware of specific limitations to our backward compatibility so these would just be the limits of what we're testing.

## Related Tickets & Documents
Closes #697

## PR Checklist
**General**
- [x] PR includes a summary of changes
- [x] Link relevant issues, make one if none exist
- [x] Add a brief summary of changes to `docs/release-notes.rst` in a relevant section for the upcoming release.
- [x] Add appropriate labels to this PR
- [x] PR follows the [Contributor's Guide](https://geocat-comp.readthedocs.io/en/stable/contrib.html)