### PR TITLE
Update release notes for v2025.03.0

### DIFF
--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -24,7 +24,7 @@ Internal Changes
 
 Bug Fixes
 ^^^^^^^^^
-* Unpin scipy and update ``.sph_harm`` to ``sph_harm_y`` by `Anissa Zacharias`_ in (:pr:`695`)
+* Unpin scipy and update ``sph_harm`` to ``sph_harm_y`` by `Anissa Zacharias`_ in (:pr:`695`)
 
 
 Breaking Changes

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -26,7 +26,6 @@ Bug Fixes
 ^^^^^^^^^
 * Unpin scipy and update ``sph_harm`` to ``sph_harm_y`` by `Anissa Zacharias`_ in (:pr:`695`)
 
-
 Breaking Changes
 ^^^^^^^^^^^^^^^^
 * The ``chunk_size`` parameter was removed from :func:`.decomposition` and :func:`.recomposition` in (:pr:`695`)

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -8,22 +8,28 @@
 Release Notes
 =============
 
-vYYYY.MM.## (unreleased)
-------------------------
+v2025.03.0 (March 25, 2025)
+---------------------------
+This release unpins scipy, establishes minimum version testing, and switches
+from ``yapf`` to ``ruff`` formatting.
 
 Enhancements
 ^^^^^^^^^^^^
-* Add minimum dependency version testing and address minor compatibility issues with Pandas and Xarray by
-`Katelyn FitzGerald`_ in (:pr:`699`)
+* Add minimum dependency version testing and address minor compatibility issues with Pandas and Xarray by `Katelyn FitzGerald`_ in (:pr:`699`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^
 * Reconfigure analytics by `Katelyn FitzGerald`_ in (:pr:`698`)
-* Remove `docformatter` and setup `ruff` by `Cora Schneck`_ in (:pr:`700`)
+* Remove ``docformatter`` and setup ``ruff`` by `Cora Schneck`_ in (:pr:`700`)
 
 Bug Fixes
 ^^^^^^^^^
-* Unpin scipy and update ``sph_harm`` to ``sph_harm_y`` by `Anissa Zacharias`_ in (:pr:`695`)
+* Unpin scipy and update ``.sph_harm`` to ``sph_harm_y`` by `Anissa Zacharias`_ in (:pr:`695`)
+
+
+Breaking Changes
+^^^^^^^^^^^^^^^^
+* The ``chunk_size`` parameter was removed from :func:`.decomposition` and :func:`.recomposition` in (:pr:`695`)
 
 v2025.02.0 (February 25, 2025)
 ------------------------------


### PR DESCRIPTION
## PR Summary
Updates release notes, adds a point about removing `chunk_size` param being a breaking change, adds sphinx linking to referenced functions

## Related Tickets & Documents
Part of #703 

## PR Checklist
**General**
- [x] PR includes a summary of changes
- [x] Link relevant issues, make one if none exist
- [n/a] Add a brief summary of changes to `docs/release-notes.rst` in a relevant section for the upcoming release.
- [x] Add appropriate labels to this PR
- [x] PR follows the [Contributor's Guide](https://geocat-comp.readthedocs.io/en/stable/contrib.html)