### PR TITLE
Support updates

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -99,4 +99,4 @@ novel computational functions for geosciences data.
 
    Support <support>
    GitHub Issues <https://github.com/NCAR/geocat-comp/issues>
-   Feature Request Form <https://forms.gle/6DTo3ELLri4DAGfG8>
+   Suggestion Box <https://forms.gle/6DTo3ELLri4DAGfG8>

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -8,6 +8,14 @@
 Release Notes
 =============
 
+vYYYY.MM.## (unreleased)
+------------------------
+This release...
+
+Documentation
+^^^^^^^^^^^^^
+* Remove reference to NCAR/geocat repo from support page by `Katelyn FitzGerald`_ in (:pr:`709`)
+
 v2025.03.0 (March 25, 2025)
 ---------------------------
 This release unpins scipy, establishes minimum version testing, and switches

--- a/docs/support.rst
+++ b/docs/support.rst
@@ -14,8 +14,7 @@ Submitting Feature Requests
 ---------------------------
 Search open `issues <https://github.com/NCAR/geocat-comp/issues>`__ on the GeoCAT-comp GitHub repository to see if the
 feature you want has already been requested. If not, open an issue and follow the *feature request* template provided.
-If you are not comfortable with GitHub issues, you can fill out `this form <https://forms.gle/6DTo3ELLri4DAGfG8>`__
-to request features.
+If you are not comfortable with GitHub issues, you can fill out `this form <https://forms.gle/6DTo3ELLri4DAGfG8>`__.
 
 Earth System Data Science (ESDS) Office Hours
 ---------------------------------------------
@@ -25,9 +24,10 @@ GeoCAT specific questions. For more info about NSF NCAR's Earth System Data Scie
 
 Have a Usage Question?
 ----------------------
-For general usage questions, please submit an issue to the overarching `GeoCAT project GitHub repository <https://github.com/NCAR/geocat>`__.
+For general usage questions, please submit an `issue  <https://github.com/NCAR/geocat-comp/issues>`__ to the GeoCAT-comp GitHub repository using the *issue* template.
+If you are not comfortable with GitHub issues, you can fill out `this form <https://forms.gle/6DTo3ELLri4DAGfG8>`__.
 
 Non-GitHub Support
 ------------------
 Not everyone is familiar with GitHub, and that's okay! If you have questions for us, you can email geocat@ucar.edu and
-someone on our team will get back to you. You can also request features through `this form <https://forms.gle/6DTo3ELLri4DAGfG8>`__.
+someone on our team will get back to you. You can also submit suggestions and feedback via `this form <https://forms.gle/6DTo3ELLri4DAGfG8>`__.


### PR DESCRIPTION
## PR Summary

The motivation for this PR was to remove the reference to the old ncar/geocat repo as a suggested support mechanism.  I opted to do that by adjusting the language and recommendations on our longer format support page.  This allows us to keep that additional content, but isn't consistent with the simplified approach used in geocat-applications or geocat-examples that just links out to GitHub issues and the GeoCAT suggestion box.  I'm inclined to keep at least viz and comp consistent, but don't have too strong of an opinion otherwise.  Curious what others think.

Currently, this PR does the following:
* Removes reference to ncar/geocat repo from support page
* Minor updates to support page language
* Changes "feature request form" to "suggestion box" for consistency

## Related Tickets & Documents
Closes #706

## PR Checklist
**General**
- [ ] PR includes a summary of changes
- [ ] Link relevant issues, make one if none exist
- [ ] Add a brief summary of changes to `docs/release-notes.rst` in a relevant section for the upcoming release.
- [ ] Add appropriate labels to this PR
- [ ] PR follows the [Contributor's Guide](https://geocat-comp.readthedocs.io/en/stable/contrib.html)
