### PR TITLE
Ensure compatibility with CFTime and Datetime objects for climatology functions

### DIFF
--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -17,6 +17,11 @@ Documentation
 * Remove reference to NCAR/geocat repo from support page by `Katelyn FitzGerald`_ in (:pr:`709`)
 * Add additional relative humidity documentation by `Cora Schneck`_ in (:pr:`710`)
 
+Bug Fixes
+^^^^^^^^^
+* Updates internal climatology function to ensure compatibility with both CFTime and Datetime
+indices by `Katelyn FitzGerald`_ in (:pr:`717`)
+
 Internal Changes
 ^^^^^^^^^^^^^^^^
 * Updates Github Actions workflows per new guidance by `Cora Schneck`_ in (:pr:`716`)

--- a/geocat/comp/climatologies.py
+++ b/geocat/comp/climatologies.py
@@ -90,7 +90,12 @@ def _calculate_center_of_time_bounds(
     See `xarray.cftime_range <https://docs.xarray.dev/en/stable/generated/xarray.cftime_range.html>`__ for accepted values for `freq` and `calendar`.
     """
 
-    time_bounds = xr.cftime_range(start, end, freq=freq, calendar=calendar)
+    if isinstance(start, cftime.datetime):
+        time_bounds = xr.date_range(start=start, end=end, freq=freq, calendar=calendar, use_cftime=True)
+    elif isinstance(start, str):
+        time_bounds = xr.date_range(start=start, end=end, freq=freq, calendar=calendar, use_cftime=True)
+    else:
+        time_bounds = xr.date_range(start=start, end=end, freq=freq, calendar=calendar)
     time_bounds = time_bounds.append(time_bounds[-1:].shift(1, freq=freq))
     time = xr.DataArray(
         np.vstack((time_bounds[:-1], time_bounds[1:])).T, dims=[time_dim, 'nbd']

--- a/geocat/comp/climatologies.py
+++ b/geocat/comp/climatologies.py
@@ -91,9 +91,13 @@ def _calculate_center_of_time_bounds(
     """
 
     if isinstance(start, cftime.datetime):
-        time_bounds = xr.date_range(start=start, end=end, freq=freq, calendar=calendar, use_cftime=True)
+        time_bounds = xr.date_range(
+            start=start, end=end, freq=freq, calendar=calendar, use_cftime=True
+        )
     elif isinstance(start, str):
-        time_bounds = xr.date_range(start=start, end=end, freq=freq, calendar=calendar, use_cftime=True)
+        time_bounds = xr.date_range(
+            start=start, end=end, freq=freq, calendar=calendar, use_cftime=True
+        )
     else:
         time_bounds = xr.date_range(start=start, end=end, freq=freq, calendar=calendar)
     time_bounds = time_bounds.append(time_bounds[-1:].shift(1, freq=freq))

--- a/test/test_climatologies.py
+++ b/test/test_climatologies.py
@@ -1022,7 +1022,7 @@ class Test_Climatology_Average:
 
     def test_datetime_climatology_average(self) -> None:
         array = self.daily['data']
-        if xarray_version < Version('2025.01.2'):
+        if Version(xarray_version) < Version('2025.01.2'):
             array['time'] = array.time.to_index().to_datetimeindex()
         else:
             array['time'] = array.time.to_index().to_datetimeindex(time_unit='ns')

--- a/test/test_climatologies.py
+++ b/test/test_climatologies.py
@@ -48,7 +48,7 @@ def _get_dummy_data(start_date, end_date, freq, nlats, nlons, calendar='standard
     Data can be hourly, daily, or monthly.
     """
     # Coordinates
-    time = xr.cftime_range(start=start_date, end=end_date, freq=freq, calendar=calendar)
+    time = xr.date_range(start=start_date, end=end_date, freq=freq, calendar=calendar, use_cftime=True)
     lats = np.linspace(start=-90, stop=90, num=nlats, dtype='float32')
     lons = np.linspace(start=-180, stop=180, num=nlons, dtype='float32')
 
@@ -84,7 +84,7 @@ class Test_Climate_Anomaly:
                 'data': (('time', 'lat', 'lon'), np.reshape(expected_anom, (731, 1, 1)))
             },
             coords={
-                'time': xr.cftime_range(start='2020-01-01', end='2021-12-31', freq='D'),
+                'time': xr.date_range(start='2020-01-01', end='2021-12-31', freq='D', use_cftime=True),
                 'lat': [-90],
                 'lon': [-180],
             },
@@ -127,7 +127,7 @@ class Test_Climate_Anomaly:
                 'data': (('time', 'lat', 'lon'), np.reshape(expected_anom, (731, 1, 1)))
             },
             coords={
-                'time': xr.cftime_range(start='2020-01-01', end='2021-12-31', freq='D'),
+                'time': xr.date_range(start='2020-01-01', end='2021-12-31', freq='D', use_cftime=True),
                 'lat': [-90],
                 'lon': [-180],
             },
@@ -167,7 +167,7 @@ class Test_Climate_Anomaly:
                 'data': (('time', 'lat', 'lon'), np.reshape(expected_anom, (731, 1, 1)))
             },
             coords={
-                'time': xr.cftime_range(start='2020-01-01', end='2021-12-31', freq='D'),
+                'time': xr.date_range(start='2020-01-01', end='2021-12-31', freq='D', use_cftime=True),
                 'lat': [-90],
                 'lon': [-180],
                 'season': ('time', seasons),
@@ -184,7 +184,7 @@ class Test_Climate_Anomaly:
                 'data': (('time', 'lat', 'lon'), np.reshape(expected_anom, (731, 1, 1)))
             },
             coords={
-                'time': xr.cftime_range(start='2020-01-01', end='2021-12-31', freq='D'),
+                'time': xr.date_range(start='2020-01-01', end='2021-12-31', freq='D', use_cftime=True),
                 'lat': [-90],
                 'lon': [-180],
             },
@@ -252,8 +252,8 @@ class Test_Climate_Anomaly:
                 )
             },
             coords={
-                time_dim: xr.cftime_range(
-                    start='2020-01-01', end='2021-12-31', freq='D'
+                time_dim: xr.date_range(
+                    start='2020-01-01', end='2021-12-31', freq='D', use_cftime=True
                 ),
                 'lat': [-90],
                 'lon': [-180],
@@ -398,7 +398,7 @@ class Test_Calendar_Average:
             715,
         ]
     ).reshape(24, 1, 1)
-    month_avg_time = xr.cftime_range('2020-01-01', '2022-01-01', freq='MS')
+    month_avg_time = xr.date_range('2020-01-01', '2022-01-01', freq='MS', use_cftime=True)
     month_avg_time = xr.DataArray(
         np.vstack((month_avg_time[:-1], month_avg_time[1:])).T, dims=['time', 'nbd']
     ).mean(dim='nbd')
@@ -410,7 +410,7 @@ class Test_Calendar_Average:
     season_avg = np.array(
         [29.5, 105.5, 197.5, 289, 379.5, 470.5, 562.5, 654, 715]
     ).reshape(9, 1, 1)
-    season_avg_time = xr.cftime_range('2019-12-01', '2022-03-01', freq='QS-DEC')
+    season_avg_time = xr.date_range('2019-12-01', '2022-03-01', freq='QS-DEC', use_cftime=True)
     season_avg_time = xr.DataArray(
         np.vstack((season_avg_time[:-1], season_avg_time[1:])).T, dims=['time', 'nbd']
     ).mean(dim='nbd')
@@ -484,8 +484,8 @@ class Test_Calendar_Average:
             715,
         ]
     ).reshape(24, 1, 1)
-    julian_month_avg_time = xr.cftime_range(
-        '2020-01-01', '2022-01-01', freq='MS', calendar='julian'
+    julian_month_avg_time = xr.date_range(
+        '2020-01-01', '2022-01-01', freq='MS', calendar='julian', use_cftime=True
     )
     julian_month_avg_time = xr.DataArray(
         np.vstack((julian_month_avg_time[:-1], julian_month_avg_time[1:])).T,
@@ -524,8 +524,8 @@ class Test_Calendar_Average:
             714,
         ]
     ).reshape(24, 1, 1)
-    noleap_month_avg_time = xr.cftime_range(
-        '2020-01-01', '2022-01-01', freq='MS', calendar='noleap'
+    noleap_month_avg_time = xr.date_range(
+        '2020-01-01', '2022-01-01', freq='MS', calendar='noleap', use_cftime=True
     )
     noleap_month_avg_time = xr.DataArray(
         np.vstack((noleap_month_avg_time[:-1], noleap_month_avg_time[1:])).T,
@@ -564,8 +564,8 @@ class Test_Calendar_Average:
             716,
         ]
     ).reshape(24, 1, 1)
-    all_leap_month_avg_time = xr.cftime_range(
-        '2020-01-01', '2022-01-01', freq='MS', calendar='all_leap'
+    all_leap_month_avg_time = xr.date_range(
+        '2020-01-01', '2022-01-01', freq='MS', calendar='all_leap', use_cftime=True
     )
     all_leap_month_avg_time = xr.DataArray(
         np.vstack((all_leap_month_avg_time[:-1], all_leap_month_avg_time[1:])).T,
@@ -577,8 +577,8 @@ class Test_Calendar_Average:
     )
     # Daily -> Monthly Means for 360 Day Calendar
     day_360_leap_month_avg = np.arange(14.5, 734.5, 30).reshape(24, 1, 1)
-    day_360_leap_month_avg_time = xr.cftime_range(
-        '2020-01-01', '2022-01-01', freq='MS', calendar='360_day'
+    day_360_leap_month_avg_time = xr.date_range(
+        '2020-01-01', '2022-01-01', freq='MS', calendar='360_day', use_cftime=True
     )
     day_360_leap_month_avg_time = xr.DataArray(
         np.vstack(
@@ -614,8 +614,8 @@ class Test_Calendar_Average:
 
     def test_30min_to_hourly_calendar_average(self) -> None:
         hour_avg = np.arange(0.5, 35088.5, 2).reshape((365 + 366) * 24, 1, 1)
-        hour_avg_time = xr.cftime_range(
-            '2020-01-01 00:30:00', '2021-12-31 23:30:00', freq='h'
+        hour_avg_time = xr.date_range(
+            '2020-01-01 00:30:00', '2021-12-31 23:30:00', freq='h', use_cftime=True
         )
         min_2_hour_avg = xr.Dataset(
             data_vars={'data': (('time', 'lat', 'lon'), hour_avg)},
@@ -627,8 +627,8 @@ class Test_Calendar_Average:
 
     def test_hourly_to_daily_calendar_average(self) -> None:
         day_avg = np.arange(11.5, 17555.5, 24).reshape(366 + 365, 1, 1)
-        day_avg_time = xr.cftime_range(
-            '2020-01-01 12:00:00', '2021-12-31 12:00:00', freq='D'
+        day_avg_time = xr.date_range(
+            '2020-01-01 12:00:00', '2021-12-31 12:00:00', freq='D', use_cftime=True
         )
         hour_2_day_avg = xr.Dataset(
             data_vars={'data': (('time', 'lat', 'lon'), day_avg)},
@@ -666,7 +666,7 @@ class Test_Calendar_Average:
                 715,
             ]
         ).reshape(24, 1, 1)
-        month_avg_time = xr.cftime_range('2020-01-01', '2022-01-01', freq='MS')
+        month_avg_time = xr.date_range('2020-01-01', '2022-01-01', freq='MS', use_cftime=True)
         month_avg_time = xr.DataArray(
             np.vstack((month_avg_time[:-1], month_avg_time[1:])).T, dims=['time', 'nbd']
         ).mean(dim='nbd')
@@ -766,8 +766,8 @@ class Test_Climatology_Average:
             np.arange(11640.5, 26328.5, 2),
         ]
     ).reshape(8784, 1, 1)
-    hour_clim_time = xr.cftime_range(
-        '2020-01-01 00:30:00', '2020-12-31 23:30:00', freq='h'
+    hour_clim_time = xr.date_range(
+        '2020-01-01 00:30:00', '2020-12-31 23:30:00', freq='h', use_cftime=True
     )
     min_2_hourly_clim = xr.Dataset(
         data_vars={'data': (('time', 'lat', 'lon'), hour_clim)},
@@ -776,8 +776,8 @@ class Test_Climatology_Average:
     day_clim = np.concatenate(
         [np.arange(4403.5, 5819.5, 24), [1427.5], np.arange(5831.5, 13175.5, 24)]
     ).reshape(366, 1, 1)
-    day_clim_time = xr.cftime_range(
-        '2020-01-01 12:00:00', '2020-12-31 12:00:00', freq='24h'
+    day_clim_time = xr.date_range(
+        '2020-01-01 12:00:00', '2020-12-31 12:00:00', freq='24h', use_cftime=True
     )
 
     hour_2_day_clim = xr.Dataset(
@@ -787,7 +787,7 @@ class Test_Climatology_Average:
     month_clim = np.array(
         [198, 224.5438596, 257.5, 288, 318.5, 349, 379.5, 410.5, 441, 471.5, 502, 532.5]
     ).reshape(12, 1, 1)
-    month_clim_time = xr.cftime_range('2020-01-01', '2021-01-01', freq='MS')
+    month_clim_time = xr.date_range('2020-01-01', '2021-01-01', freq='MS', use_cftime=True)
     month_clim_time = xr.DataArray(
         np.vstack((month_clim_time[:-1], month_clim_time[1:])).T, dims=['time', 'nbd']
     ).mean(dim='nbd')
@@ -847,8 +847,8 @@ class Test_Climatology_Average:
             532.5,
         ]
     ).reshape(12, 1, 1)
-    julian_month_clim_time = xr.cftime_range(
-        '2020-01-01', '2021-01-01', freq='MS', calendar='julian'
+    julian_month_clim_time = xr.date_range(
+        '2020-01-01', '2021-01-01', freq='MS', calendar='julian', use_cftime=True
     )
     julian_month_clim_time = xr.DataArray(
         np.vstack((julian_month_clim_time[:-1], julian_month_clim_time[1:])).T,
@@ -862,8 +862,8 @@ class Test_Climatology_Average:
     noleap_month_clim = np.array(
         [197.5, 227, 256.5, 287, 317.5, 348, 378.5, 409.5, 440, 470.5, 501, 531.5]
     ).reshape(12, 1, 1)
-    noleap_month_clim_time = xr.cftime_range(
-        '2020-01-01', '2021-01-01', freq='MS', calendar='noleap'
+    noleap_month_clim_time = xr.date_range(
+        '2020-01-01', '2021-01-01', freq='MS', calendar='noleap', use_cftime=True
     )
     noleap_month_clim_time = xr.DataArray(
         np.vstack((noleap_month_clim_time[:-1], noleap_month_clim_time[1:])).T,
@@ -877,8 +877,8 @@ class Test_Climatology_Average:
     all_leap_month_clim = np.array(
         [198, 228, 258, 288.5, 319, 349.5, 380, 411, 441.5, 472, 502.5, 533]
     ).reshape(12, 1, 1)
-    all_leap_month_clim_time = xr.cftime_range(
-        '2020-01-01', '2021-01-01', freq='MS', calendar='all_leap'
+    all_leap_month_clim_time = xr.date_range(
+        '2020-01-01', '2021-01-01', freq='MS', calendar='all_leap', use_cftime=True
     )
     all_leap_month_clim_time = xr.DataArray(
         np.vstack((all_leap_month_clim_time[:-1], all_leap_month_clim_time[1:])).T,
@@ -890,8 +890,8 @@ class Test_Climatology_Average:
     )
     # Daily -> Monthly Climatologies for 360 Day Calendar
     day_360_leap_month_clim = np.arange(194.5, 554.5, 30).reshape(12, 1, 1)
-    day_360_leap_month_clim_time = xr.cftime_range(
-        '2020-01-01', '2021-01-01', freq='MS', calendar='360_day'
+    day_360_leap_month_clim_time = xr.date_range(
+        '2020-01-01', '2021-01-01', freq='MS', calendar='360_day', use_cftime=True
     )
     day_360_leap_month_clim_time = xr.DataArray(
         np.vstack(

--- a/test/test_climatologies.py
+++ b/test/test_climatologies.py
@@ -1000,6 +1000,13 @@ class Test_Climatology_Average:
         result = climatology_average(array, freq='month')
         xr.testing.assert_allclose(result, array_expected)
 
+    def test_datetime_climatology_average(self) -> None:
+        array = self.daily['data']
+        array['time'] = array.time.to_index().to_datetimeindex()
+        array_expected = self.day_2_month_clim['data']
+        result = climatology_average(array, freq='month')
+        xr.testing.assert_allclose(result, array_expected)
+
     def test_non_datetime_like_objects_climatology_average(self) -> None:
         dset_encoded = xr.tutorial.open_dataset("air_temperature", decode_cf=False)
         with pytest.raises(ValueError):

--- a/test/test_climatologies.py
+++ b/test/test_climatologies.py
@@ -1,9 +1,11 @@
 import cftime
 import numpy as np
+from packaging.version import Version
 import pandas as pd
 import pytest
 import xarray.testing
 import xarray as xr
+from xarray import __version__ as xarray_version
 
 from geocat.comp import (
     climate_anomaly,
@@ -1020,7 +1022,10 @@ class Test_Climatology_Average:
 
     def test_datetime_climatology_average(self) -> None:
         array = self.daily['data']
-        array['time'] = array.time.to_index().to_datetimeindex(time_unit='ns')
+        if xarray_version < Version('2025.01.2'):
+            array['time'] = array.time.to_index().to_datetimeindex()
+        else:
+            array['time'] = array.time.to_index().to_datetimeindex(time_unit='ns')
         array_expected = self.day_2_month_clim['data']
         result = climatology_average(array, freq='month')
         xr.testing.assert_allclose(result, array_expected)

--- a/test/test_climatologies.py
+++ b/test/test_climatologies.py
@@ -1002,7 +1002,7 @@ class Test_Climatology_Average:
 
     def test_datetime_climatology_average(self) -> None:
         array = self.daily['data']
-        array['time'] = array.time.to_index().to_datetimeindex()
+        array['time'] = array.time.to_index().to_datetimeindex(time_unit='ns')
         array_expected = self.day_2_month_clim['data']
         result = climatology_average(array, freq='month')
         xr.testing.assert_allclose(result, array_expected)

--- a/test/test_climatologies.py
+++ b/test/test_climatologies.py
@@ -48,7 +48,9 @@ def _get_dummy_data(start_date, end_date, freq, nlats, nlons, calendar='standard
     Data can be hourly, daily, or monthly.
     """
     # Coordinates
-    time = xr.date_range(start=start_date, end=end_date, freq=freq, calendar=calendar, use_cftime=True)
+    time = xr.date_range(
+        start=start_date, end=end_date, freq=freq, calendar=calendar, use_cftime=True
+    )
     lats = np.linspace(start=-90, stop=90, num=nlats, dtype='float32')
     lons = np.linspace(start=-180, stop=180, num=nlons, dtype='float32')
 
@@ -84,7 +86,9 @@ class Test_Climate_Anomaly:
                 'data': (('time', 'lat', 'lon'), np.reshape(expected_anom, (731, 1, 1)))
             },
             coords={
-                'time': xr.date_range(start='2020-01-01', end='2021-12-31', freq='D', use_cftime=True),
+                'time': xr.date_range(
+                    start='2020-01-01', end='2021-12-31', freq='D', use_cftime=True
+                ),
                 'lat': [-90],
                 'lon': [-180],
             },
@@ -127,7 +131,9 @@ class Test_Climate_Anomaly:
                 'data': (('time', 'lat', 'lon'), np.reshape(expected_anom, (731, 1, 1)))
             },
             coords={
-                'time': xr.date_range(start='2020-01-01', end='2021-12-31', freq='D', use_cftime=True),
+                'time': xr.date_range(
+                    start='2020-01-01', end='2021-12-31', freq='D', use_cftime=True
+                ),
                 'lat': [-90],
                 'lon': [-180],
             },
@@ -167,7 +173,9 @@ class Test_Climate_Anomaly:
                 'data': (('time', 'lat', 'lon'), np.reshape(expected_anom, (731, 1, 1)))
             },
             coords={
-                'time': xr.date_range(start='2020-01-01', end='2021-12-31', freq='D', use_cftime=True),
+                'time': xr.date_range(
+                    start='2020-01-01', end='2021-12-31', freq='D', use_cftime=True
+                ),
                 'lat': [-90],
                 'lon': [-180],
                 'season': ('time', seasons),
@@ -184,7 +192,9 @@ class Test_Climate_Anomaly:
                 'data': (('time', 'lat', 'lon'), np.reshape(expected_anom, (731, 1, 1)))
             },
             coords={
-                'time': xr.date_range(start='2020-01-01', end='2021-12-31', freq='D', use_cftime=True),
+                'time': xr.date_range(
+                    start='2020-01-01', end='2021-12-31', freq='D', use_cftime=True
+                ),
                 'lat': [-90],
                 'lon': [-180],
             },
@@ -398,7 +408,9 @@ class Test_Calendar_Average:
             715,
         ]
     ).reshape(24, 1, 1)
-    month_avg_time = xr.date_range('2020-01-01', '2022-01-01', freq='MS', use_cftime=True)
+    month_avg_time = xr.date_range(
+        '2020-01-01', '2022-01-01', freq='MS', use_cftime=True
+    )
     month_avg_time = xr.DataArray(
         np.vstack((month_avg_time[:-1], month_avg_time[1:])).T, dims=['time', 'nbd']
     ).mean(dim='nbd')
@@ -410,7 +422,9 @@ class Test_Calendar_Average:
     season_avg = np.array(
         [29.5, 105.5, 197.5, 289, 379.5, 470.5, 562.5, 654, 715]
     ).reshape(9, 1, 1)
-    season_avg_time = xr.date_range('2019-12-01', '2022-03-01', freq='QS-DEC', use_cftime=True)
+    season_avg_time = xr.date_range(
+        '2019-12-01', '2022-03-01', freq='QS-DEC', use_cftime=True
+    )
     season_avg_time = xr.DataArray(
         np.vstack((season_avg_time[:-1], season_avg_time[1:])).T, dims=['time', 'nbd']
     ).mean(dim='nbd')
@@ -666,7 +680,9 @@ class Test_Calendar_Average:
                 715,
             ]
         ).reshape(24, 1, 1)
-        month_avg_time = xr.date_range('2020-01-01', '2022-01-01', freq='MS', use_cftime=True)
+        month_avg_time = xr.date_range(
+            '2020-01-01', '2022-01-01', freq='MS', use_cftime=True
+        )
         month_avg_time = xr.DataArray(
             np.vstack((month_avg_time[:-1], month_avg_time[1:])).T, dims=['time', 'nbd']
         ).mean(dim='nbd')
@@ -787,7 +803,9 @@ class Test_Climatology_Average:
     month_clim = np.array(
         [198, 224.5438596, 257.5, 288, 318.5, 349, 379.5, 410.5, 441, 471.5, 502, 532.5]
     ).reshape(12, 1, 1)
-    month_clim_time = xr.date_range('2020-01-01', '2021-01-01', freq='MS', use_cftime=True)
+    month_clim_time = xr.date_range(
+        '2020-01-01', '2021-01-01', freq='MS', use_cftime=True
+    )
     month_clim_time = xr.DataArray(
         np.vstack((month_clim_time[:-1], month_clim_time[1:])).T, dims=['time', 'nbd']
     ).mean(dim='nbd')


### PR DESCRIPTION
## PR Summary

Does the following:
* Adapts `_calculate_center_of_time_bounds` to ensure compatibility with CFTime and Datetime objects for climatology functions
* Adds test coverage for the above
* Updates related functions to minimize deprecation warnings

## Related Tickets & Documents
Closes #692

## PR Checklist
**General**
- [x] PR includes a summary of changes
- [x] Link relevant issues, make one if none exist
- [x] Add a brief summary of changes to `docs/release-notes.rst` in a relevant section for the upcoming release.
- [x] Add appropriate labels to this PR
- [x] PR follows the [Contributor's Guide](https://geocat-comp.readthedocs.io/en/stable/contrib.html)

**Testing**
- [x] Update or create tests in appropriate test file