### PR TITLE
Update delta_pressure docs

### DIFF
--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -16,6 +16,7 @@ Documentation
 ^^^^^^^^^^^^^
 * Remove reference to NCAR/geocat repo from support page by `Katelyn FitzGerald`_ in (:pr:`709`)
 * Add additional relative humidity documentation by `Cora Schneck`_ in (:pr:`710`)
+* Clarify definition of ``delta_pressure`` by `Katelyn FitzGerald`_ in (:pr:`718`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/geocat/comp/meteorology.py
+++ b/geocat/comp/meteorology.py
@@ -1852,7 +1852,9 @@ def saturation_vapor_pressure_slope(
 
 def _delta_pressure1D(pressure_lev, surface_pressure):
     """Helper function for `delta_pressure`. Calculates the pressure layer
-    thickness (delta pressure) of a one-dimensional pressure level array.
+    thickness, i.e. the change in pressure (delta pressure), for each layer
+    in a one-dimensional pressure level array taking into account a
+    specified surface pressure.
 
     Returns an array of length matching `pressure_lev`.
 
@@ -1924,8 +1926,9 @@ def _delta_pressure1D(pressure_lev, surface_pressure):
 
 
 def delta_pressure(pressure_lev, surface_pressure):
-    """Calculates the pressure layer thickness (delta pressure) of a constant
-    pressure level coordinate system.
+    """Calculates the pressure layer thickness, i.e. the change in pressure
+    (delta pressure), for each layer in a specified constant pressure level
+    coordinate system and accounting for specified surface pressure(s).
 
     Returns an array of shape matching (``surface_pressure``, ``pressure_lev``).
 


### PR DESCRIPTION
## PR Summary
Updates the `delta_pressure` docstrings to clarify that thickness is here is referring to the difference in pressure rather than e.g. height between pressure levels.

## Related Tickets & Documents
Closes #635

## PR Checklist
**General**
- [x] PR includes a summary of changes
- [x] Link relevant issues, make one if none exist
- [x] Add a brief summary of changes to `docs/release-notes.rst` in a relevant section for the upcoming release.
- [x] Add appropriate labels to this PR
- [x] PR follows the [Contributor's Guide](https://geocat-comp.readthedocs.io/en/stable/contrib.html)
