### PR TITLE
ASV Update

### DIFF
--- a/.github/workflows/asv-benchmarking.yml
+++ b/.github/workflows/asv-benchmarking.yml
@@ -77,7 +77,7 @@ jobs:
         run: |
           cd benchmarks
           asv machine --machine GH-Actions --os ubuntu-latest --arch x64 --cpu "2-core unknown" --ram 7GB
-          asv run v2023.02.0..main --skip-existing --parallel || true
+          asv run v2024.04.0..main --skip-existing --parallel || true
 
       - name: Commit and push benchmark results
         run: |

--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -21,11 +21,11 @@
     // Customizable commands for building the project.
     // See asv.conf.json documentation.
     // To build the package using pyproject.toml (PEP518), uncomment the following lines
-    // "build_command": [
-    //     "python -m pip install build",
-    //     "python -m build",
-    //     "PIP_NO_BUILD_ISOLATION=false python -mpip wheel --no-deps --no-index -w {build_cache_dir} {build_dir}"
-    // ],
+    "build_command": [
+        "python -m pip install build",
+        "python -m build",
+        "PIP_NO_BUILD_ISOLATION=false python -mpip wheel --no-deps --no-index -w {build_cache_dir} {build_dir}"
+    ],
     // To build the package using setuptools and a setup.py file, uncomment the following lines
     // "build_command": [
     //     "python setup.py build",
@@ -65,7 +65,7 @@
 
     // The Pythons you'd like to test against.  If not provided, defaults
     // to the current version of Python used to run `asv`.
-    "pythons": ["3.10"],
+    "pythons": ["3.10", "3.13"],
 
     // The list of conda channel names to be searched for benchmark
     // dependency packages in the specified order
@@ -94,9 +94,9 @@
     // new environments.  A value of ``null`` means that the variable
     // will not be set for the current combination.
     //
-    "matrix": {
-        "python": [""],
-    },
+    // "matrix": {
+    //     "python": [""],
+    // },
 
     // Combinations of libraries/python versions can be excluded/included
     // from the set to test. Each entry is a dictionary containing additional

--- a/build_envs/asv-bench.yml
+++ b/build_envs/asv-bench.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - python=3.10
-  - asv<0.6.2
+  - asv
   - cf_xarray
   - cftime
   - cython

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -27,6 +27,7 @@ Internal Changes
 ^^^^^^^^^^^^^^^^
 * Updates Github Actions workflows per new guidance by `Cora Schneck`_ in (:pr:`716`)
 * Adds `blackdoc` to linter for rst and markdown by `Cora Schneck`_ in (:pr:`720`)
+* Unpins ``asv`` and adds Python 3.13 to benchmarking matrix by `Anissa Zacharias`_ in (:pr:`722`)
 
 v2025.03.0 (March 25, 2025)
 ---------------------------


### PR DESCRIPTION
## PR Summary

This PR:
- unpins asv
- adds `python=3.13` to the test matrix
- bumps up the farthest back-run commit to v2024.04.0 from v2023.02.0 to limit the amout of commits that newly-added benchmarks will be tried over

The bulk of work on this PR was actually verifying it was working from my fork. Here's how I (eventually) confirmed that the asv unpin and build update were working as expected:
- [Successful run](https://github.com/anissa111/geocat-comp/actions/runs/14766054730/job/41457621756) on my fork
- [Diff of branch](https://github.com/NCAR/geocat-comp/compare/main...anissa111:asv_update?expand=1) with successful run from my fork. Note that there are a couple of differences to allow for testing from my fork in `.github/workflows/asv-benchmarking.yml`


## Related Tickets & Documents
Closes #611

## PR Checklist
**General**
- [x] PR includes a summary of changes
- [x] Link relevant issues, make one if none exist
- [x] Add a brief summary of changes to `docs/release-notes.rst` in a relevant section for the upcoming release.
- [x] Add appropriate labels to this PR
- [x] PR follows the [Contributor's Guide](https://geocat-comp.readthedocs.io/en/stable/contrib.html)
