### PR TITLE
Correct `psychrometric_constant` references

### DIFF
--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -17,7 +17,7 @@ Documentation
 * Remove reference to NCAR/geocat repo from support page by `Katelyn FitzGerald`_ in (:pr:`709`)
 * Add additional relative humidity documentation by `Cora Schneck`_ in (:pr:`710`)
 * Clarify definition of ``delta_pressure`` by `Katelyn FitzGerald`_ in (:pr:`718`)
-* Correct `psychrometric_constant` equation references in documentation by `Cora Schneck`_ in (:pr:`723`)
+* Correct ``psychrometric_constant`` equation references in documentation by `Cora Schneck`_ in (:pr:`723`)
 
 Bug Fixes
 ^^^^^^^^^

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -17,6 +17,7 @@ Documentation
 * Remove reference to NCAR/geocat repo from support page by `Katelyn FitzGerald`_ in (:pr:`709`)
 * Add additional relative humidity documentation by `Cora Schneck`_ in (:pr:`710`)
 * Clarify definition of ``delta_pressure`` by `Katelyn FitzGerald`_ in (:pr:`718`)
+* Correct `psychrometric_constant` equation references in documentation by `Cora Schneck`_ in (:pr:`723`)
 
 Bug Fixes
 ^^^^^^^^^

--- a/geocat/comp/meteorology.py
+++ b/geocat/comp/meteorology.py
@@ -1557,8 +1557,10 @@ def psychrometric_constant(
     """Compute psychrometric constant [kPa / C] as described in the Food and
     Agriculture Organization (FAO) Irrigation and Drainage Paper 56 entitled:
 
-    Crop evapotranspiration - Guidelines for computing crop water
-    requirement. Specifically, see equation 7 of Chapter 3 or equation 3-2 in
+    "Crop evapotranspiration - Guidelines for computing crop water
+    requirement"
+    
+    Specifically, see equation 8 of Chapter 3 or equation 3-10 in
     Annex 3.
 
     From FAO 56:

--- a/geocat/comp/meteorology.py
+++ b/geocat/comp/meteorology.py
@@ -1559,7 +1559,7 @@ def psychrometric_constant(
 
     "Crop evapotranspiration - Guidelines for computing crop water
     requirement"
-    
+
     Specifically, see equation 8 of Chapter 3 or equation 3-10 in
     Annex 3.
 


### PR DESCRIPTION
## PR Summary
Fix equation reference for `psychrometric_constant` in geocat-comp (and eventually in associated place in NCL documentation)

Referenced corrected within the code to [Equation 8](https://github.com/NCAR/geocat-comp/blob/55efd3826344161642d3452581af975809dda35a/geocat/comp/meteorology.py#L1618), but not in the documentation

## Related Tickets & Documents
Closes #721

## PR Checklist
**General**
- [x] PR includes a summary of changes
- [x] Link relevant issues, make one if none exist
- [x] Add a brief summary of changes to `docs/release-notes.rst` in a relevant section for the upcoming release.
- [x] Add appropriate labels to this PR
- [x] PR follows the [Contributor's Guide](https://geocat-comp.readthedocs.io/en/stable/contrib.html)
<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://geocat-comp.readthedocs.io/en/stable/contrib.html

- Fork this repository and open the PR from your fork. Do not directly work on
  the NCAR/geocat-comp repository.

- The PR title should summarize the changes, for example "Create weighted pearson-r
  correlation coefficient function". Avoid non-descriptive titles such as "Addresses
  issue #229".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- The summary in `docs/release-notes.rst` should be written as " 'Summary of changes'
  by `FirstName LastName`_ in (:pr:`PR#`) ". For first time contributors, add your new
  name and GitHub link to bottom of `docs/release-notes.rst` as _`FirstName LastName`
  :https://github.com/githubUsername

- When merging, we prefer to use squash commits.

- You can install pre-commit hooks and then run them locally with `pre-commit run --all-files`

**PR Etiquette Reminders**
- This PR should be listed as a draft PR until you are ready to request reviewers

- After making changes in accordance with the reviews, re-request your reviewers

- Generally, don't mark conversations as resolved if you didn't open them

- Do mark conversations as resolved *if you opened them* and are satisfied with the changes/discussion.

If you need assistance with your PR, please let the GeoCAT team know by
tagging us with @NCAR/geocat. We can help if reviews are unclear, the recommended changes
seem overly demanding, you would like help in addressing a reviewer's comments,
or if you have been waiting more than a week to hear back on your PR.
-->
