### PR TITLE
Delta pressure near surface thickness bugfix

### DIFF
--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -21,6 +21,7 @@ Documentation
 
 Bug Fixes
 ^^^^^^^^^
+* Update near surface pressure thickness calculations in ``delta_pressure`` for consistency with NCL by `Katelyn FitzGerald`_ in (:pr:`726`)
 * Updates internal climatology function to ensure compatibility with both CFTime and Datetime
 indices by `Katelyn FitzGerald`_ in (:pr:`717`)
 

--- a/geocat/comp/meteorology.py
+++ b/geocat/comp/meteorology.py
@@ -1897,7 +1897,7 @@ def _delta_pressure1D(pressure_lev, surface_pressure):
         pressure_lev = np.flip(pressure_lev)
 
     # Calculate delta pressure
-    delta_pressure = np.full_like(pressure_lev, np.nan)
+    delta_pressure = np.full_like(pressure_lev, np.nan, dtype=float)
 
     # Determine which layers to calculate thickness for based upon midpoints
     midpoints = (pressure_lev + np.roll(pressure_lev, shift=1))/2

--- a/geocat/comp/meteorology.py
+++ b/geocat/comp/meteorology.py
@@ -1899,7 +1899,10 @@ def _delta_pressure1D(pressure_lev, surface_pressure):
     # Calculate delta pressure
     delta_pressure = np.full_like(pressure_lev, np.nan)
 
-    [indices] = np.nonzero(np.array(pressure_lev) <= surface_pressure)
+    # Determine which layers to calculate thickness for based upon midpoints
+    midpoints = (pressure_lev + np.roll(pressure_lev, shift=1))/2
+    midpoints[0] = 0
+    [indices] = np.nonzero(midpoints < surface_pressure)
 
     start_level = min(indices)
     end_level = max(indices)

--- a/geocat/comp/meteorology.py
+++ b/geocat/comp/meteorology.py
@@ -1900,8 +1900,8 @@ def _delta_pressure1D(pressure_lev, surface_pressure):
     delta_pressure = np.full_like(pressure_lev, np.nan, dtype=float)
 
     # Determine which layers to calculate thickness for based upon midpoints
-    midpoints = (pressure_lev + np.roll(pressure_lev, shift=1)) / 2
-    midpoints[0] = 0
+    midpoints = np.array((pressure_lev + np.roll(pressure_lev, shift=1)) / 2.0)
+    midpoints[0] = 0.0
     [indices] = np.nonzero(midpoints < surface_pressure)
 
     start_level = min(indices)

--- a/geocat/comp/meteorology.py
+++ b/geocat/comp/meteorology.py
@@ -1900,7 +1900,7 @@ def _delta_pressure1D(pressure_lev, surface_pressure):
     delta_pressure = np.full_like(pressure_lev, np.nan, dtype=float)
 
     # Determine which layers to calculate thickness for based upon midpoints
-    midpoints = (pressure_lev + np.roll(pressure_lev, shift=1))/2
+    midpoints = (pressure_lev + np.roll(pressure_lev, shift=1)) / 2
     midpoints[0] = 0
     [indices] = np.nonzero(midpoints < surface_pressure)
 

--- a/test/test_meteorology.py
+++ b/test/test_meteorology.py
@@ -686,6 +686,7 @@ class Test_Delta_Pressure:
         surface_pressure_adjusted = 50.0
         delta_p = delta_pressure(pressure_lev, surface_pressure_adjusted)
         assert np.nansum(delta_p) == (surface_pressure_adjusted - min(pressure_lev))
+        assert np.sum(np.isnan(delta_p)) == 2
 
     def test_negative_pressure_error(self) -> None:
         pressure_lev_negative = self.pressure_lev.copy()


### PR DESCRIPTION
## PR Summary
Changes near surface thickness calculations in `delta_pressure` to be consistent with NCL (i.e. based upon the midpoints).

Adds test coverage.

And reminded me we could probably use to optimize this code.  

## Related Tickets & Documents
Closes #725

## PR Checklist
**General**
- [x] PR includes a summary of changes
- [x] Link relevant issues, make one if none exist
- [x] Add a brief summary of changes to `docs/release-notes.rst` in a relevant section for the upcoming release.
- [x] Add appropriate labels to this PR
- [x] PR follows the [Contributor's Guide](https://geocat-comp.readthedocs.io/en/stable/contrib.html)
