### PR TITLE
Add note to `interp_hybrid_to_pressure` docs

### DIFF
--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -18,6 +18,7 @@ Documentation
 * Add additional relative humidity documentation by `Cora Schneck`_ in (:pr:`710`)
 * Clarify definition of ``delta_pressure`` by `Katelyn FitzGerald`_ in (:pr:`718`)
 * Correct ``psychrometric_constant`` equation references in documentation by `Cora Schneck`_ in (:pr:`723`)
+* Add note about alternate hybrid-sigma pressure formulation to ``interp_hybrid_to_pressure`` docs by `Katelyn FitzGerald`_ in (:pr:`727`)
 
 Bug Fixes
 ^^^^^^^^^

--- a/geocat/comp/interpolation.py
+++ b/geocat/comp/interpolation.py
@@ -366,6 +366,15 @@ def interp_hybrid_to_pressure(
 
     Notes
     -----
+    Atmosphere hybrid-sigma pressure coordinates are commonly defined in two different
+    ways as described below and in CF Conventions. This particular function expects the
+    first formulation. However, with some minor adjustments on the user side it can
+    support datasets leveraging the second formulation as well.  In this case, you can
+    set the input parameters p0=1 and hyam=ap to adapt the function to meet your needs.
+
+    Formulation 1: p(n,k,j,i) = a(k)*p0 + b(k)*ps(n,j,i)
+    Formulation 2: p(n,k,j,i) = ap(k) + b(k)*ps(n,j,i)
+
     ACKNOWLEDGEMENT: We'd like to thank to `Brian Medeiros <https://github.com/brianpm>`__,
     `Matthew Long <https://github.com/matt-long>`__, and `Deepak Cherian <https://github.com/dcherian>`__
     at NSF NCAR for their great contributions since the code implemented here is mostly


### PR DESCRIPTION
## PR Summary
Adds a note to the `interp_hybrid_to_pressure` docstring with info regarding how to adapt the function for use with an alternate hybrid-sigma pressure formulation.

## Related Tickets & Documents
Closes #689

## PR Checklist
**General**
- [x] PR includes a summary of changes
- [x] Link relevant issues, make one if none exist
- [x] Add a brief summary of changes to `docs/release-notes.rst` in a relevant section for the upcoming release.
- [x] Add appropriate labels to this PR
- [x] PR follows the [Contributor's Guide](https://geocat-comp.readthedocs.io/en/stable/contrib.html)