### PR TITLE
Change `interp_hybrid_to_pressure` temperature extrapolation to use `t_bot` directly

### DIFF
--- a/test/test_interpolation.py
+++ b/test/test_interpolation.py
@@ -166,7 +166,7 @@ class Test_interp_hybrid_to_pressure_extrapolate:
             method="linear",
             extrapolate=True,
             variable='temperature',
-            t_bot=t_bot,
+            t_bot=temp_in.isel(lev= -1, drop=True),
             phi_sfc=phis,
         )
         result = result.transpose('time', 'plev', 'lat', 'lon')


### PR DESCRIPTION
## PR Summary
Changes the `interp_hybrid_to_pressure` temperature extrapolation to use `t_bot` directly rather than using the presumed lower level of the input temperature data which relies upon the vertical coordinate being indexed in a certain direction.

The prior behavior was, as far as I can tell, inherited from NCL.  However, the assumption this relies upon was [documented there](https://www.ncl.ucar.edu/Document/Functions/Built-in/vinth2p_ecmwf.shtml) whereas we failed to do so or test for it in GeoCAT-comp.

Interestingly, we required an input for `t_bot` in GeoCAT-comp when extrapolation is set to `True`, but ignored it for the temperature extrapolation previously (likely also inherited behavior from NCL).  Leveraging `t_bot` directly avoids the issue with indexing and gives more control to the user to define the temperature field they would like to use.  However, it does change the answers in some cases.  For example, in the relevant test we assign `t_bot` as the surface temperature field, which is slightly different from the lowest temperature level and therefore results in a different answer.  I adjusted the specification of `t_bot` there for consistency with the NCL results.

Based upon the GeoCAT-comp documentation, this new behavior is what I would have expected the whole time so I think it makes sense to treat this as a bug fix.  It'd be great to get other's perspective on this though.      

## Related Tickets & Documents
Closes #735 

## PR Checklist
**General**
- [ ] PR includes a summary of changes
- [ ] Link relevant issues, make one if none exist
- [ ] Add a brief summary of changes to `docs/release-notes.rst` in a relevant section for the upcoming release.
- [ ] Add appropriate labels to this PR
- [ ] PR follows the [Contributor's Guide](https://geocat-comp.readthedocs.io/en/stable/contrib.html)