### PR TITLE
Replace deprecated `xarray.cftime_range` with `xarray.date_range`

### DIFF
--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -16,6 +16,10 @@ Bug Fixes
 ^^^^^^^^^
 * Change ``interp_hybrid_to_pressure`` to use ``t_bot`` directly for temperature extrapolation rather than the temperature from the (sometimes incorrectly) presumed lowest level by `Katelyn FitzGerald`_ in (:pr:`737`)
 
+Internal Changes
+^^^^^^^^^^^^^^^^
+* Replace deprecated ``xarray.cftime_range`` with ``xarray.date_range`` by `Katelyn FitzGerald`_ in (:pr:`739`)
+
 v2025.05.0 (May 20, 2025)
 ------------------------
 This release includes documentation improvements, fixes a delta_pressure

--- a/geocat/comp/climatologies.py
+++ b/geocat/comp/climatologies.py
@@ -87,7 +87,7 @@ def _calculate_center_of_time_bounds(
 
     Notes
     -----
-    See `xarray.cftime_range <https://docs.xarray.dev/en/stable/generated/xarray.cftime_range.html>`__ for accepted values for `freq` and `calendar`.
+    See `xarray.date_range <https://docs.xarray.dev/en/stable/generated/xarray.date_range.html>`__ for accepted values for `freq` and `calendar`.
     """
 
     if isinstance(start, cftime.datetime):

--- a/test/test_stats.py
+++ b/test/test_stats.py
@@ -499,7 +499,7 @@ class Test_eof_ts(BaseEOFTestClass):
 
 class Test_pearson_r:
     # Coordinates
-    times = xr.cftime_range(start='2022-08-01', end='2022-08-05', freq='D')
+    times = xr.date_range(start='2022-08-01', end='2022-08-05', freq='D', use_cftime=True)
     lats = np.linspace(start=-45, stop=45, num=3, dtype='float32')
     lons = np.linspace(start=-180, stop=180, num=4, dtype='float32')
 

--- a/test/test_stats.py
+++ b/test/test_stats.py
@@ -499,7 +499,9 @@ class Test_eof_ts(BaseEOFTestClass):
 
 class Test_pearson_r:
     # Coordinates
-    times = xr.date_range(start='2022-08-01', end='2022-08-05', freq='D', use_cftime=True)
+    times = xr.date_range(
+        start='2022-08-01', end='2022-08-05', freq='D', use_cftime=True
+    )
     lats = np.linspace(start=-45, stop=45, num=3, dtype='float32')
     lons = np.linspace(start=-180, stop=180, num=4, dtype='float32')
 


### PR DESCRIPTION
## PR Summary
Replaces deprecated `xarray.cftime_range` with `xarray.date_range`.

If I remember correctly, I did a bit of this before in some of the climatology PRs, but I must have missed this elsewhere in the code.

## Related Tickets & Documents
Closes #738

## PR Checklist
**General**
- [x] PR includes a summary of changes
- [x] Link relevant issues, make one if none exist
- [x] Add a brief summary of changes to `docs/release-notes.rst` in a relevant section for the upcoming release.
- [x] Add appropriate labels to this PR
- [x] PR follows the [Contributor's Guide](https://geocat-comp.readthedocs.io/en/stable/contrib.html)