### PR TITLE
Revert blackdoc version in pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
     - id: check-yaml               # Check valid yml file
 
 -   repo: https://github.com/keewis/blackdoc
-    rev: v0.4.3
+    rev: v0.4.1
     hooks:
     - id: blackdoc
       additional_dependencies: [ "black==25.1.0" ]


### PR DESCRIPTION
## PR Summary
Reverts the blackdoc version for pre-commit to avoid the issue causing a check to fail in #768.

Ideally we'd more fully diagnose this issue and report upstream, but I haven't made it that far yet and this will keep things working for the time being

## PR Checklist
**General**
- [ ] PR includes a summary of changes
- [ ] Link relevant issues, make one if none exist
- [ ] Add a brief summary of changes to `docs/release-notes.rst` in a relevant section for the upcoming release.
- [ ] Add appropriate labels to this PR
- [ ] PR follows the [Contributor's Guide](https://geocat-comp.readthedocs.io/en/stable/contrib.html)
