### PR TITLE
Fix Upstream CI installation issue

### DIFF
--- a/ci/install-upstream.sh
+++ b/ci/install-upstream.sh
@@ -30,6 +30,8 @@ python -m pip install \
 
 # install rest from source
 python -m pip install \
+    --no-deps \
+    --upgrade \
     git+https://github.com/xarray-contrib/cf-xarray.git \
     git+https://github.com/dask/dask.git \
     git+https://github.com/dask/distributed.git \


### PR DESCRIPTION
## PR Summary
This should get the Upstream CI Dask installs working again (tested on my fork [here](https://github.com/kafitzgerald/geocat-comp/actions/runs/19213464729)).  

Unfortunately, the runs are still failing from the Xarray attrs change (addressed by #783).

## Related Tickets & Documents
Relates to #777 

## PR Checklist
**General**
- [x] PR includes a summary of changes
- [x] Link relevant issues, make one if none exist
- [x] Add a brief summary of changes to `docs/release-notes.rst` in a relevant section for the upcoming release.
- [x] Add appropriate labels to this PR
- [x] PR follows the [Contributor's Guide](https://geocat-comp.readthedocs.io/en/stable/contrib.html)
