### PR TITLE
Temporarily pin micromamba version in CI

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -30,6 +30,7 @@ jobs:
         continue-on-error: true
         uses: mamba-org/setup-micromamba@d7c9bd84e824b79d2af72a2d4196c7f4300d3476 # v2
         with:
+          micromamba-version: '2.6.0-0'
           environment-name: import_test
           create-args: >-
             python=${{ matrix.python-version }}
@@ -75,6 +76,7 @@ jobs:
         continue-on-error: true
         uses: mamba-org/setup-micromamba@d7c9bd84e824b79d2af72a2d4196c7f4300d3476 # v2
         with:
+          micromamba-version: '2.6.0-0'
           environment-name: import_test
           create-args: >-
             python=${{ matrix.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
         continue-on-error: true
         uses: mamba-org/setup-micromamba@d7c9bd84e824b79d2af72a2d4196c7f4300d3476 # v2
         with:
+          micromamba-version: '2.6.0-0'
           environment-file: ${{ env.CONDA_ENV_FILE }}
           cache-environment: true
           cache-environment-key: "CI ${{runner.os}}-${{runner.arch}}-py${{matrix.python-version}}-${{env.TODAY}}"

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -8,6 +8,27 @@
 Release Notes
 =============
 
+vYYYY.MM.## (unreleased)
+------------------------
+This release...
+
+New Features
+^^^^^^^^^^^^
+
+Breaking Changes
+^^^^^^^^^^^^^^^^
+
+Bug Fixes
+^^^^^^^^^
+
+Internal Changes
+^^^^^^^^^^^^^^^^
+* Pin micromamba version in CI by `Katelyn FitzGerald`_ in (:pr:`855`)
+
+Documentation
+^^^^^^^^^^^^^
+
+
 v2026.04.0 (April 21, 2026)
 ------------------------
 This release has updates to fix upstream testing, setup dependabot cooldown, updates to the PR template, moves data files for testing into a new subdirectory, and updates the github release notes template


### PR DESCRIPTION
## PR Summary
Temporarily pin the micromamba version in CI to avoid failures on the Window builds.

## Related Tickets & Documents
Closes #736 

## PR Checklist
**General**
- [x] PR includes a summary of changes
- [x] Link relevant issues, make one if none exist
- [x] Add a brief summary of changes to `docs/release-notes.rst` in a relevant section for the upcoming release.
- [x] Add appropriate labels to this PR
- [x] PR follows the [Contributor's Guide](https://geocat-comp.readthedocs.io/en/stable/contrib.html)
