### PR TITLE
Remove micromamba version pin from CI

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -30,7 +30,6 @@ jobs:
         continue-on-error: true
         uses: mamba-org/setup-micromamba@d7c9bd84e824b79d2af72a2d4196c7f4300d3476 # v2
         with:
-          micromamba-version: '2.6.0-0'
           environment-name: import_test
           create-args: >-
             python=${{ matrix.python-version }}
@@ -76,7 +75,6 @@ jobs:
         continue-on-error: true
         uses: mamba-org/setup-micromamba@d7c9bd84e824b79d2af72a2d4196c7f4300d3476 # v2
         with:
-          micromamba-version: '2.6.0-0'
           environment-name: import_test
           create-args: >-
             python=${{ matrix.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,6 @@ jobs:
         continue-on-error: true
         uses: mamba-org/setup-micromamba@d7c9bd84e824b79d2af72a2d4196c7f4300d3476 # v2
         with:
-          micromamba-version: '2.6.0-0'
           environment-file: ${{ env.CONDA_ENV_FILE }}
           cache-environment: true
           cache-environment-key: "CI ${{runner.os}}-${{runner.arch}}-py${{matrix.python-version}}-${{env.TODAY}}"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-| CI           | [![GitHub Workflow Status][github-ci-badge]][github-ci-link] [![GitHub Workflow Status][github-upstream-ci-badge]][github-upstream-ci-link] [![Code Coverage Status][codecov-badge]][codecov-link] [![asv-badge]][asv-link] |
+| CI           | [![GitHub Workflow Status][github-ci-badge]][github-ci-link] [![Code Coverage Status][codecov-badge]][codecov-link] [![asv-badge]][asv-link] |
 | :----------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: |
 | **Docs**     |                                                                    [![Documentation Status][rtd-badge]][rtd-link]                                                                    |
 | **Package**  |                            [![Conda][conda-badge]][conda-link] [![PyPI][pypi-badge]][pypi-link] [![Python Version][python-version-badge]][python-version-badge-link]                 |
@@ -37,8 +37,6 @@ https://geocat-comp.readthedocs.io/en/latest/citation.html) page.
 
 [github-ci-badge]: https://img.shields.io/github/actions/workflow/status/NCAR/geocat-comp/ci.yml?branch=main&label=CI&style=for-the-badge
 [github-ci-link]: https://github.com/NCAR/geocat-comp/actions/workflows/ci.yml
-[github-upstream-ci-badge]: https://img.shields.io/github/actions/workflow/status/NCAR/geocat-comp/upstream-dev-ci.yml?branch=main&label=Upstream%20CI&style=for-the-badge
-[github-upstream-ci-link]: https://github.com/NCAR/geocat-comp/actions/workflows/upstream-dev-ci.yml
 [codecov-badge]: https://img.shields.io/codecov/c/github/NCAR/geocat-comp.svg?logo=codecov&style=for-the-badge&color=brightgreen
 [codecov-link]: https://codecov.io/gh/NCAR/geocat-comp/coverage.yml
 [asv-badge]: https://img.shields.io/badge/benchmarked%20by-asv-green.svg?style=for-the-badge

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -23,7 +23,6 @@ Bug Fixes
 
 Internal Changes
 ^^^^^^^^^^^^^^^^
-* Pin micromamba version in CI by `Katelyn FitzGerald`_ in (:pr:`855`)
 
 Documentation
 ^^^^^^^^^^^^^


### PR DESCRIPTION
## PR Summary
Removes the micromamba version pin from CI and the release note (no longer relevant).

Also removes the CI Upstream badge from the README since it's not particularly relevant to users and more something for devs to monitor.

## Related Tickets & Documents
Closes #856 

## PR Checklist
**General**
- [x] PR includes a summary of changes
- [x] Link relevant issues, make one if none exist
- [x] Add a brief summary of changes to `docs/release-notes.rst` in a relevant section for the upcoming release.
- [x] Add appropriate labels to this PR
- [x] PR follows the [Contributor's Guide](https://geocat-comp.readthedocs.io/en/stable/contrib.html)
